### PR TITLE
Fix micropurchase-staging

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -369,12 +369,16 @@ resource "aws_route53_record" "18f_gov_methods_18f_gov_cname" {
   records = ["d1z8tmjf5ismhl.cloudfront.net."]
 }
 
-resource "aws_route53_record" "18f_gov_micropurchase-staging_18f_gov_cname" {
+# Configured with CDN Broker
+resource "aws_route53_record" "18f_gov_micropurchase-staging_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "micropurchase-staging.18f.gov."
-  type = "CNAME"
-  ttl = 300
-  records = ["d148p0zbwe5pp7.cloudfront.net."]  
+  type = "A"
+  alias {
+    name = "d148p0zbwe5pp7.cloudfront.net."
+    zone_id = "Z35SXDOTRQ7X7K"
+    evaluate_target_health = false
+  }
 }
 
 resource "aws_route53_record" "18f_gov_micropurchase-staging_18f_gov_mx" {


### PR DESCRIPTION
Revert back to A record.

Concourse build failed because there a lot of other records.
Exact error in concourse:
```
InvalidChangeBatch: RRSet of type CNAME with DNS name micropurchase-staging.18f.gov. is not permitted as it conflicts with other records with the same DNS name in zone 18f.gov.
```

Reference to general solution: http://stackoverflow.com/questions/20215729/rrset-of-type-cname-with-dns-name-foo-com-is-not-permitted-at-apex-in-zone-bar