### PR TITLE
Micropurchase Staging: Use Cloudfront Zone Z2FDTNDATAQYW2

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -376,7 +376,7 @@ resource "aws_route53_record" "18f_gov_micropurchase-staging_18f_gov_a" {
   type = "A"
   alias {
     name = "d148p0zbwe5pp7.cloudfront.net."
-    zone_id = "Z35SXDOTRQ7X7K"
+    zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
   }
 }


### PR DESCRIPTION
All CloudFront Distributions use Zone Id Z2FDTNDATAQYW2. This PR does that for micropurchase-staging

Last PR used wrong zone id.
Error in concourse: `InvalidChangeBatch: Tried to create an alias that targets d148p0zbwe5pp7.cloudfront.net., type A in zone Z35SXDOTRQ7X7K, but the alias target name does not lie within the target zone`

Reference: https://forums.aws.amazon.com/message.jspa?messageID=493441