### PR TITLE
Add Route53 zone and records for digitalgov

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -1,0 +1,42 @@
+resource "aws_route53_zone" "digitalgov_gov_zone" {
+  name = "digitalgov.gov."
+  tags {
+    Project = "dns"
+  }
+}
+
+resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_cname" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "openopps.digitalgov.gov."
+  type = "CNAME"
+  ttl = 300
+  records = [ "d11og6pgwhrztr.cloudfront.net." ]
+}
+
+resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_mx" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "openopps.digitalgov.gov."
+  type = "MX"
+  ttl = 300
+  records = ["10	30288227.in1.mandrillapp.com", "20	30288227.in2.mandrillapp.com"]
+}
+
+resource "aws_route53_record" "digitalgov_gov_openopps-staging_digitalgov_gov_txt" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "openopps.digitalgov.gov."
+  type = "TXT"
+  ttl = 300
+  records = ["v=spf1 include:spf.mandrillapp.com ?all"]
+}
+
+resource "aws_route53_record" "digitalgov_gov_mandrill__domainkey_openopps-staging_digitalgov_gov_txt" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "mandrill._domainkey.openopps.digitalgov.gov."
+  type = "TXT"
+  ttl = 300
+  records = ["v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrLHiExVd55zd/IQ/J/mRwSRMAocV/hMB3jXwaHH36d9NaVynQFYV8NaWi69c1veUtRzGt7yAioXqLj7Z4TeEUoOLgrKsn8YnckGs9i3B3tVFB+Ch/4mPhXWiNfNdynHWBcPcbJ8kjEQ2U8y78dHZj1YeRXXVvWob2OaKynO8/lQIDAQAB;"]
+}
+
+ouput "digitalgov_gov_ns" {
+  value="${aws_route53_zone.digitalgov_gov_zone.name_servers}"
+}

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -37,6 +37,6 @@ resource "aws_route53_record" "digitalgov_gov_mandrill__domainkey_openopps-stagi
   records = ["v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrLHiExVd55zd/IQ/J/mRwSRMAocV/hMB3jXwaHH36d9NaVynQFYV8NaWi69c1veUtRzGt7yAioXqLj7Z4TeEUoOLgrKsn8YnckGs9i3B3tVFB+Ch/4mPhXWiNfNdynHWBcPcbJ8kjEQ2U8y78dHZj1YeRXXVvWob2OaKynO8/lQIDAQAB;"]
 }
 
-ouput "digitalgov_gov_ns" {
+output "digitalgov_gov_ns" {
   value="${aws_route53_zone.digitalgov_gov_zone.name_servers}"
 }


### PR DESCRIPTION
Related to the work being done on openopps/openopps-platform#1499. We'll need to coordinate on when to get this merged in. We're waiting until Friday for now while we communicate to users that the app will have a certificate error while the CDN broker sets up the certificate.
cc: @erik-burgess