### PR TITLE
Remove federalist-landing-template-proxied.18f.gov

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -247,14 +247,6 @@ resource "aws_route53_record" "18f_gov_federalist-landing-template_18f_gov_cname
   records = ["d2lwrtx2u5nmdw.cloudfront.net"]
 }
 
-resource "aws_route53_record" "18f_gov_federalist-landing-template-proxied_18f_gov_cname" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "federalist-landing-template-proxied.18f.gov."
-  type = "CNAME"
-  ttl = 60
-  records = ["d2m6dqe40rj9bp.cloudfront.net"]
-}
-
 resource "aws_route53_record" "18f_gov_85333a5c6cd71f56532894c3c64666ca_federalist-docs_18f_gov_cname" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "85333a5c6cd71f56532894c3c64666ca.federalist-docs.18f.gov."


### PR DESCRIPTION
This subdomain was used to demonstrate HSTS to GSAIT and can be decommissioned now that that is complete.

cc: @wslack 