### PR TITLE
Fix the zone_id

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_a" {
   type = "A"
   alias {
     name = "d11og6pgwhrztr.cloudfront.net."
-    zone_id = "Z2XX41ZRDBUGDX"
+    zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
   }
 }


### PR DESCRIPTION
cc: @erik-burgess

From the documentation here,
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget.html
> For CloudFront, use Z2FDTNDATAQYW2.