### PR TITLE
updated the fedramp resource record

### DIFF
--- a/terraform/cloud.gov.tf
+++ b/terraform/cloud.gov.tf
@@ -574,7 +574,7 @@ resource "aws_route53_record" "fedramp_sitesusa_app_cloud_gov_cname" {
   name = "fedramp.sitesusa.app.cloud.gov."
   type = "CNAME"
   ttl = 60
-  records = ["d1w3nfychfack8.cloudfront.net."]
+  records = ["dpaxq4usmh07x.cloudfront.net."]
 }
 
 output "cloud_gov_ns" {


### PR DESCRIPTION
Updated the fedramp resource record - I didn't fully read the docs and deleted the route instead of just updating it.

If this works, and the subdomain resolves properly we will be adding in like 45 more subdomains. Should I put those into the cloud.gv.tf file or make a new file?