### PR TITLE
Point www.vote.gov to the USA.gov redirector

### DIFF
--- a/terraform/vote.gov.tf
+++ b/terraform/vote.gov.tf
@@ -37,7 +37,7 @@ resource "aws_route53_record" "vote_gov_www_vote_gov_a" {
   name = "www.vote.gov."
   type = "A"
   alias {
-    name = "d2s5gzwyabrtbd.cloudfront.net"
+    name = "54.85.132.205"
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
   }


### PR DESCRIPTION
Note the change is only happening for the `www` host. Discussion in #ffd-vote.