### PR TITLE
Adding transiton.fec.gov

### DIFF
--- a/terraform/transition.fec.gov.tf
+++ b/terraform/transition.fec.gov.tf
@@ -1,0 +1,10 @@
+resource "aws_route53_zone" "fec_transiton_us_zone" {
+  name = "transition.fec.gov"
+  tags {
+    Project = "dns"
+  }
+}
+
+output "fec_transiton_us_ns" {
+  value="${aws_route53_zone.18f_us_zone.name_servers}"
+}


### PR DESCRIPTION
Adding transiton.fec.gov that we can add the route to our [proxy](https://github.com/18F/fec-proxy) app. That will then serve content from an s3 bucket in cloud.gov gov cloud.

Note: PRs affecting cloud.gov or Federalist must receive approval from a member of the relevant team.
