### PR TITLE
transition.fec.gov CNAME to proxy app in govcloud

### DIFF
--- a/terraform/transition.fec.gov.tf
+++ b/terraform/transition.fec.gov.tf
@@ -1,10 +1,18 @@
-resource "aws_route53_zone" "fec_transiton_us_zone" {
+resource "aws_route53_zone" "transition_gov_us_zone" {
   name = "transition.fec.gov"
   tags {
     Project = "dns"
   }
 }
 
-output "fec_transiton_us_ns" {
-  value="${aws_route53_zone.18f_us_zone.name_servers}"
+resource "aws_route53_record" "transition_gov_transition_gov_cname" {
+  zone_id = "${aws_route53_zone.transition_gov_us_zone.zone_id}"
+  name = "transition.fec.gov"
+  type = "CNAME"
+  ttl = 60
+  records = ["d2p6ccc3xlipxg.cloudfront.net"]
+}
+
+output "transition_gov_us_ns" {
+  value="${aws_route53_zone.transition_gov_us_zone.name_servers}"
 }


### PR DESCRIPTION
Note: PRs affecting cloud.gov or Federalist must receive approval from a member of the relevant team.
