### PR TITLE
change transition.fec.gov record to A alias

### DIFF
--- a/terraform/transition.fec.gov.tf
+++ b/terraform/transition.fec.gov.tf
@@ -8,9 +8,12 @@ resource "aws_route53_zone" "transition_gov_us_zone" {
 resource "aws_route53_record" "transition_gov_transition_gov_cname" {
   zone_id = "${aws_route53_zone.transition_gov_us_zone.zone_id}"
   name = "transition.fec.gov"
-  type = "CNAME"
-  ttl = 60
-  records = ["d2p6ccc3xlipxg.cloudfront.net"]
+  type = "A"
+  alias {
+    name = "d2p6ccc3xlipxg.cloudfront.net"
+    zone_id = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
 }
 
 output "transition_gov_us_ns" {


### PR DESCRIPTION
Note: PRs affecting cloud.gov or Federalist must receive approval from a member of the relevant team.
