### PR TITLE
overhauling DNS settings for code.gov

### DIFF
--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -12,7 +12,7 @@ resource "aws_route53_record" "code_gov_apex" {
   type = "A"
 
   alias {
-    name = "d3qovtf6opsrko.cloudfront.net."
+    name = "dqziuvpgrykcy.cloudfront.net."
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
   }
@@ -24,11 +24,20 @@ resource "aws_route53_record" "code_gov_www" {
   type = "A"
 
   alias {
-    name = "d3qovtf6opsrko.cloudfront.net."
+    name = "dqziuvpgrykcy.cloudfront.net."
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
   }
 }
+
+resource "aws_route53_record" "staging_code_gov_cname" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "staging.code.gov."
+  type = "CNAME"
+  ttl = 60
+  records = ["d3g0jy911fqt1l.cloudfront.net"]
+}
+
 
 output "code_ns" {
   value="${aws_route53_zone.code_toplevel.name_servers}"


### PR DESCRIPTION
not confident in the A records I put in (specifically leaving the Zone ID alone); please check them.

Note: PRs affecting cloud.gov or Federalist must receive approval from a member of the relevant team.
