### PR TITLE
Adding ads.18f.gov to govcloud DNS

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -108,13 +108,13 @@ resource "aws_route53_record" "18f_gov_qegrzvzekq4wiompgqufe4xwmarm37lh__domaink
 }
 
 resource "aws_route53_record" "18f_gov_ads_18f_gov_a" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "ads.18f.gov."
-  type = "A"
-  alias {
-    name = "d1p50apr0w92d2.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "ads.18f.gov."
+  type = "A"
+  alias {
+    name = "d1p50apr0w92d2.cloudfront.net."
+    zone_id = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
   }
 }
 

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -112,7 +112,7 @@ resource "aws_route53_record" "18f_gov_ads_18f_gov_a" {
   name = "ads.18f.gov."
   type = "A"
   alias {
-    name = "<d1p50apr0w92d2.cloudfront.net>."
+    name = "d1p50apr0w92d2.cloudfront.net."
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
   }

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -107,6 +107,17 @@ resource "aws_route53_record" "18f_gov_qegrzvzekq4wiompgqufe4xwmarm37lh__domaink
   records = ["qegrzvzekq4wiompgqufe4xwmarm37lh.dkim.amazonses.com"]
 }
 
+resource "aws_route53_record" "18f_gov_ads_18f_gov_a" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "ads.18f.gov."
+  type = "A"
+  alias {
+    name = "<d1p50apr0w92d2.cloudfront.net>."
+    zone_id = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "18f_gov_autoapi_18f_gov_cname" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "autoapi.18f.gov."

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -115,7 +115,7 @@ resource "aws_route53_record" "18f_gov_ads_18f_gov_a" {
     name = "d1p50apr0w92d2.cloudfront.net."
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
-  }
+  }
 }
 
 resource "aws_route53_record" "18f_gov_autoapi_18f_gov_cname" {


### PR DESCRIPTION
Guinea pig #1

Note: PRs affecting cloud.gov or Federalist must receive approval from a member of the relevant team.
