### PR TITLE
update PR template with clearer guidance

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,1 @@
-Note: PRs affecting cloud.gov or Federalist must receive approval from a member of the relevant team.
+PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.


### PR DESCRIPTION
Note: PRs affecting cloud.gov or Federalist must receive approval from a member of the relevant team.
