### PR TITLE
Ensure only one deploy runs at a time.

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,5 +1,6 @@
 jobs:
 - name: dns-prod
+  serial: true
   plan:
   - aggregate:
     - get: pipeline-tasks


### PR DESCRIPTION
Terraform state locking will make this less of an issue once we upgrade
to the latest version.