### PR TITLE
corrected lean product design

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -683,7 +683,7 @@ resource "aws_route53_record" "18f_gov_join_18f_gov_cname" {
 
 resource "aws_route53_record" "18f_gov_lean-product-design_18f_gov-route_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "lean-product-design.18f.gov-route."
+  name = "lean-product-design.18f.gov."
   type = "A"
   alias {
     name = "d2rme39iqpbarz.cloudfront.net."


### PR DESCRIPTION
Because of

```
* aws_route53_record.18f_gov_lean-product-design_18f_gov-route_a: [ERR]: Error building changeset: InvalidChangeBatch: FATAL problem: DomainLabelEmpty (Domain label is empty) encountered with 'lean-product-design.18f.gov-route..18f.gov'
    status code: 400, request id: d8939b10-2ec0-11e7-95ad-4fd5c0979f86

```