### PR TITLE
add new guides DNS records

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -604,6 +604,17 @@ resource "aws_route53_record" "18f_gov_star_sys_green_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "18f_gov_guides_18f_gov_a" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "guides.18f.gov."
+  type = "A"
+  alias {
+    name = "d1n7tjr4lotmf0.cloudfront.net."
+    zone_id = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "18f_gov_guides-template_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "guides-template.18f.gov."


### PR DESCRIPTION
PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.
