### PR TITLE
add new apps.gov cloudfront distribution

### DIFF
--- a/terraform/apps.gov.tf
+++ b/terraform/apps.gov.tf
@@ -10,7 +10,7 @@ resource "aws_route53_record" "apps_gov_apps_gov_a" {
   name = "apps.gov."
   type = "A"
   alias {
-    name = "d37tzfgd0a69in.cloudfront.net."
+    name = "d24f99alwtdu0h.cloudfront.net."
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
   }

--- a/terraform/apps.gov.tf
+++ b/terraform/apps.gov.tf
@@ -93,7 +93,7 @@ resource "aws_route53_record" "apps_gov_www_apps_gov_a" {
   name = "www.apps.gov."
   type = "A"
   alias {
-    name = "d37tzfgd0a69in.cloudfront.net."
+    name = "d24f99alwtdu0h.cloudfront.net."
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
   }


### PR DESCRIPTION
PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.
