### PR TITLE
Remove fec-style DNS entry

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -463,17 +463,6 @@ resource "aws_route53_record" "18f_gov_dolores_staging_18f_gov_cname" {
   records = ["d9d5ti9w8z48u.cloudfront.net"]
 }
 
-resource "aws_route53_record" "18f_gov_fec-style_18f_gov_a" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "fec-style.18f.gov."
-  type = "A"
-  alias {
-    name = "d338bxxszxjap2.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
-}
-
 resource "aws_route53_record" "18f_gov_federalist_18f_gov_cname" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "federalist.18f.gov."


### PR DESCRIPTION
We are creating a new style guide for the FEC project and no longer need the original one built on 18F pages.  This changeset removes the DNS entry for the old guide so we can re-use it with the new one.

PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.

/cc @wslack 