### PR TITLE
Set state backend to s3.

### DIFF
--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -2,6 +2,10 @@ provider "aws" {
   region = "us-east-1"
 }
 
+terraform {
+  backend "s3" {}
+}
+
 variable "cloudfront_zone_id" {
   default = "Z33AYJ8TM3BH4J"
 }


### PR DESCRIPTION
Because `cg-pipeline-tasks` upgraded to terraform 0.9.x, which configures remote state differently.