### PR TITLE
Add Circleci 2 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: hashicorop/terraform:0.8.2
+
+    environment:
+      TERRAFORM_VERSION: "0.8.2"
+
+    steps:
+      - checkout
+      - run: terraform validate terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: hashicorop/terraform:0.8.2
-
-    environment:
-      TERRAFORM_VERSION: "0.8.2"
+      - image: hashicorp/terraform:0.9.11
 
     steps:
       - checkout


### PR DESCRIPTION
Adds a configuration for Circle CI (2.0) into the build and deployment process for the DNS repo per [#842](https://github.com/18F/Infrastructure/issues/842) that should be compatible with the current CI build solution