### PR TITLE
Set cloud.gov spf record to fail

### DIFF
--- a/terraform/cloud.gov.tf
+++ b/terraform/cloud.gov.tf
@@ -58,7 +58,7 @@ resource "aws_route53_record" "cloud_gov_cloud_gov_txt" {
   name = "cloud.gov."
   type = "TXT"
   ttl = 300
-  records = ["v=spf1 include:spf.mandrillapp.com ?all"]
+  records = ["v=spf1 include:spf.mandrillapp.com -all"]
 }
 
 resource "aws_route53_record" "cloud_gov_2a37e22b1f41ad3fe6af39f4fc38c1bc_cloud_gov_cname" {


### PR DESCRIPTION
Fail SPF if sender not in includes

PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.
