### PR TITLE
Update connect.gov cloudfront URL

### DIFF
--- a/terraform/connect.gov.tf
+++ b/terraform/connect.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "connect_gov_connect_gov_a" {
   type = "A"
 
   alias {
-    name = "d1pxy6t1mlaum7.cloudfront.net"
+    name = "d1tqmxfevhun0x.cloudfront.net"
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = true
   }
@@ -22,7 +22,7 @@ resource "aws_route53_record" "www_connect_gov_connect_gov_cname" {
   name = "www.connect.gov"
   type = "A"
   alias {
-    name = "d1pxy6t1mlaum7.cloudfront.net"
+    name = "d1tqmxfevhun0x.cloudfront.net"
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = true
   }


### PR DESCRIPTION
This commit updates the cloud front URL for connect.gov to move it from
federalist-redirects to a federalist site.
