### PR TITLE
DNS approval for new *.app.cloud.gov cert

### DIFF
--- a/terraform/cloud.gov.tf
+++ b/terraform/cloud.gov.tf
@@ -797,6 +797,14 @@ resource "aws_route53_record" "cdn_broker_delegate" {
   ]
 }
 
+resource "aws_route53_record" "star_app_cloud_gov_dv" {
+  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  name = "_baa568061ce9f20600f5faa54e0032b2.app.cloud.gov."
+  type = "NS"
+  ttl = 300
+  records = ["8025.dns-approval.sslmate.com."]
+}
+
 resource "aws_route53_record" "cloud_gov_b3b6346ca012f4c2600a876bec04df21_fr_cloud_gov_cname" {
   zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
   name = "b3b6346ca012f4c2600a876bec04df21.fr.cloud.gov."


### PR DESCRIPTION
domain validation for *.app.cloud.gov

PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.
