### PR TITLE
Moving summit.digitalgov.gov to AWS/Route53

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -5,6 +5,22 @@ resource "aws_route53_zone" "digitalgov_gov_zone" {
   }
 }
 
+
+# summit.digitalgov.gov
+resource "aws_route53_record" "summit_digitalgov_gov_a" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "summit.digitalgov.gov."
+  type = "A"
+
+  alias {
+    name = "www.usa.gov.edgekey.net."
+    zone_id = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}
+
+
+# Open Opps Records ------------------- 
 resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_a" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "openopps.digitalgov.gov."


### PR DESCRIPTION
This sub-domain summit.digitalgov.gov is no longer relevant, but we are using it as a test to see if we can move a sub-domain from GSA IT to AWS/Route53 with no down time.

I would like to also make sure that we are not breaking the existing OpenOpps records in the process.

Taking this one step at a time.

PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.
