### PR TITLE
Adding the www.digitalgov.gov record to AWS/Route53

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -5,6 +5,18 @@ resource "aws_route53_zone" "digitalgov_gov_zone" {
   }
 }
 
+# www.digitalgov.gov
+resource "aws_route53_record" "www_digitalgov_gov_digitalgov_gov_a" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "www.digitalgov.gov."
+  type = "A"
+  alias {
+    name = "djce1rrjucuix.cloudfront.net."
+    zone_id = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_a" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "openopps.digitalgov.gov."


### PR DESCRIPTION
We are going to ask GSA IT to point the `www` sub-domain of `digitalgov.gov` at CloudFront for now — thus, not having to move all the sub-domains that are currently associated with `digitalgov.gov` at this time.

This also means that we’ll be relying on the apache config that SITES program currently has in place to redirect the root `digitalgov.gov` to `www.digitalgov.gov`. If/when that goes away after Jan 31, we’ll need to figure out another solution.

For the product, this is an acceptable solution since we’ll be moving DigitalGov.gov over to the digital.gov domain in the next 3-5 months.
