### PR TITLE
Deploy new address for fugacious.18f.gov

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -609,7 +609,7 @@ resource "aws_route53_record" "18f_gov_fugacious_18f_gov_a" {
   name = "fugacious.18f.gov."
   type = "A"
   alias {
-    name = "NOTYET.cloudfront.net."
+    name = "dbifnpoekiab5.cloudfront.net."
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
   }

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -604,12 +604,15 @@ resource "aws_route53_record" "18f_gov_frontend_18f_gov_a" {
   }
 }
 
-resource "aws_route53_record" "18f_gov_fugacious_18f_gov_cname" {
+resource "aws_route53_record" "18f_gov_fugacious_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "fugacious.18f.gov."
-  type = "CNAME"
-  ttl = 300
-  records = ["dualstack.production-star-18f-gov-elb-1963420885.us-gov-west-1.elb.amazonaws.com"]
+  type = "A"
+  alias {
+    name = "NOTYET.cloudfront.net."
+    zone_id = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
 }
 
 resource "aws_route53_record" "18f_gov_govconnect_18f_gov_a" {


### PR DESCRIPTION
PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.

Do not merge yet.