### PR TITLE
upgrade Terraform in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,9 @@ version: 2
 jobs:
   build:
     docker:
-      - image: hashicorp/terraform:0.9.11
+      - image: hashicorp/terraform:0.10.8
 
     steps:
       - checkout
+      - run: terraform init -backend=false terraform
       - run: terraform validate terraform

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 credentials.yml
+.terraform/


### PR DESCRIPTION
The old version doesn't support [local values](https://www.terraform.io/docs/configuration/locals.html), which are useful. Corresponds to https://github.com/18F/cg-deploy-concourse-docker-image/pull/32, which is the Docker image used in Concourse for deployment.