### PR TITLE
refactor commonly-occurring values to use locals

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -346,7 +346,7 @@ resource "aws_route53_record" "18f_gov_cap_18f_gov_a" {
   type = "A"
   alias {
     name = "dualstack.production-star-18f-gov-elb-1963420885.us-gov-west-1.elb.amazonaws.com."
-    zone_id = "${var.cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1028,7 +1028,7 @@ resource "aws_route53_record" "18f_gov_requests_18f_gov_a" {
   type = "A"
   alias {
     name = "dualstack.production-star-18f-gov-elb-1963420885.us-gov-west-1.elb.amazonaws.com."
-    zone_id = "${var.cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "18f_gov_18f_gov_a" {
   type = "A"
   alias {
     name = "d1undivnru8ry9.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -125,7 +125,7 @@ resource "aws_route53_record" "18f_gov_18franklin_18f_gov_a" {
   type = "A"
   alias {
     name = "d3n4rzfn59k0a9.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -136,7 +136,7 @@ resource "aws_route53_record" "18f_gov_accessibility_18f_gov_a" {
   type = "A"
   alias {
     name = "d3gg23ftaba0j8.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -147,7 +147,7 @@ resource "aws_route53_record" "18f_gov_ads_18f_gov_a" {
   type = "A"
   alias {
     name = "d1p50apr0w92d2.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -158,7 +158,7 @@ resource "aws_route53_record" "18f_gov_agile_18f_gov_a" {
   type = "A"
   alias {
     name = "d2zsago6kfzgka.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -169,7 +169,7 @@ resource "aws_route53_record" "18f_gov_agile-labor-categories_18f_gov_a" {
   type = "A"
   alias {
     name = "d1p2fryyhm3d02.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -188,7 +188,7 @@ resource "aws_route53_record" "18f_gov_acqstack-journeymap_18f_gov_a" {
   type = "A"
   alias {
     name = "d283vwqoe38bia.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -199,7 +199,7 @@ resource "aws_route53_record" "18f_gov_api-all-the-x_18f_gov_a" {
   type = "A"
   alias {
     name = "d32jbnyri5gz15.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -210,7 +210,7 @@ resource "aws_route53_record" "18f_gov_api-program_18f_gov_a" {
   type = "A"
   alias {
     name = "d1o273cx53rx83.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -221,7 +221,7 @@ resource "aws_route53_record" "18f_gov_api-usability-testing_18f_gov_a" {
   type = "A"
   alias {
     name = "d3u1jtugc2nkl7.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -240,7 +240,7 @@ resource "aws_route53_record" "18f_gov_atul-docker-presentation_18f_gov_a" {
   type = "A"
   alias {
     name = "dndsei0n82g4z.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -259,7 +259,7 @@ resource "aws_route53_record" "18f_gov_automated-testing-playbook_18f_gov_a" {
   type = "A"
   alias {
     name = "d77j39fvc23g2.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -270,7 +270,7 @@ resource "aws_route53_record" "18f_gov_blogging-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "d1g22yqn5yr45v.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -281,7 +281,7 @@ resource "aws_route53_record" "18f_gov_before-you-ship_18f_gov_a" {
   type = "A"
   alias {
     name = "daap61vtgsw76.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -292,7 +292,7 @@ resource "aws_route53_record" "18f_gov_boise_18f_gov_a" {
   type = "A"
   alias {
     name = "d3va9woazp7hye.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -303,7 +303,7 @@ resource "aws_route53_record" "18f_gov_brand_18f_gov_a" {
   type = "A"
   alias {
     name = "d19y688vepyspr.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -357,7 +357,7 @@ resource "aws_route53_record" "18f_gov_chandika_18f_gov_a" {
   type = "A"
   alias {
     name = "d1vqiz8w0x796c.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -384,7 +384,7 @@ resource "aws_route53_record" "18f_gov_climate-data-user-study_18f_gov_a" {
   type = "A"
   alias {
     name = "d28r76t17zvn4f.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -403,7 +403,7 @@ resource "aws_route53_record" "18f_gov_content-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "dv941ubd2f1ex.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -414,7 +414,7 @@ resource "aws_route53_record" "18f_gov_contracting-cookbook_18f_gov_a" {
   type = "A"
   alias {
     name = "d1fftyxpeen4gs.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -433,7 +433,7 @@ resource "aws_route53_record" "18f_gov_design-principles-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "d1z8htfdnj42fu.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -444,7 +444,7 @@ resource "aws_route53_record" "18f_gov_digital-acquisition-playbook_18f_gov_a" {
   type = "A"
   alias {
     name = "d1dov9wu7ayjg9.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -455,7 +455,7 @@ resource "aws_route53_record" "18f_gov_digitalaccelerator_18f_gov_a" {
   type = "A"
   alias {
     name = "dyumdy5yvu23d.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -490,7 +490,7 @@ resource "aws_route53_record" "18f_gov_eng-hiring_18f_gov_a" {
   type = "A"
   alias {
     name = "d1ju28lhpbkq84.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -525,7 +525,7 @@ resource "aws_route53_record" "18f_gov_federalist-docs_18f_gov_a" {
   type = "A"
   alias {
     name = "dryn1azf9y010.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -560,7 +560,7 @@ resource "aws_route53_record" "18f_gov_federalist-uswds-template_18f_gov_a" {
   type = "A"
   alias {
     name = "d14safpqycg0pm.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -579,7 +579,7 @@ resource "aws_route53_record" "18f_gov_fedspendingtransparency_18f_gov_a" {
   type = "A"
   alias {
     name = "dbdhg5alj9dxm.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -590,7 +590,7 @@ resource "aws_route53_record" "18f_gov_files_18f_gov_a" {
   type = "A"
   alias {
     name = "d3gawctq7ecsbu.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -609,7 +609,7 @@ resource "aws_route53_record" "18f_gov_frontend_18f_gov_a" {
   type = "A"
   alias {
     name = "d2dhxnk13yje6c.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -620,7 +620,7 @@ resource "aws_route53_record" "18f_gov_fugacious_18f_gov_a" {
   type = "A"
   alias {
     name = "d309sw0ah4sgku.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -639,7 +639,7 @@ resource "aws_route53_record" "18f_gov_govconnect_18f_gov_a" {
   type = "A"
   alias {
     name = "d1pr8zgciesx6n.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -702,7 +702,7 @@ resource "aws_route53_record" "18f_gov_star_apps_green_18f_gov_a" {
   type = "A"
   alias {
     name = "d3ry367ji31g0v.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -724,7 +724,7 @@ resource "aws_route53_record" "18f_gov_guides_18f_gov_a" {
   type = "A"
   alias {
     name = "d1n7tjr4lotmf0.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -735,7 +735,7 @@ resource "aws_route53_record" "18f_gov_guides-template_18f_gov_a" {
   type = "A"
   alias {
     name = "d2ydp5mmbpnnqx.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -754,7 +754,7 @@ resource "aws_route53_record" "18f_gov_iaa-forms_18f_gov_a" {
   type = "A"
   alias {
     name = "d1ulaoarb8xdr6.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -765,7 +765,7 @@ resource "aws_route53_record" "18f_gov_identity-dev-docs_18f_gov_a" {
   type = "A"
   alias {
     name = "d35rhrbvrsocmo.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -776,7 +776,7 @@ resource "aws_route53_record" "18f_gov_innovation-toolkit-prototype_18f_gov_a" {
   type = "A"
   alias {
     name = "d8x9jyjnezbf9.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -804,7 +804,7 @@ resource "aws_route53_record" "18f_gov_lean-product-design_18f_gov_a" {
   type = "A"
   alias {
     name = "d2rme39iqpbarz.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -815,7 +815,7 @@ resource "aws_route53_record" "18f_gov_markdown-helper_18f_gov_a" {
   type = "A"
   alias {
     name = "doj9msj2touhw.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -826,7 +826,7 @@ resource "aws_route53_record" "18f_gov_methods_18f_gov_a" {
   type = "A"
   alias {
     name = "d2z1u02mjhp26x.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -837,7 +837,7 @@ resource "aws_route53_record" "18f_gov_micropurchase-staging_18f_gov_a" {
   type = "A"
   alias {
     name = "d148p0zbwe5pp7.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -873,7 +873,7 @@ resource "aws_route53_record" "18f_gov_micropurchase_18f_gov_a" {
   type = "A"
   alias {
     name = "d2x6i02wsoxhfc.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -908,7 +908,7 @@ resource "aws_route53_record" "18f_gov_modularcontracting_18f_gov_a" {
   type = "A"
   alias {
     name = "d1iyte5ws3y9f8.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -943,7 +943,7 @@ resource "aws_route53_record" "18f_gov_open-source-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "d217cwkdnmo5gb.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -954,7 +954,7 @@ resource "aws_route53_record" "18f_gov_open-source-program_18f_gov_a" {
   type = "A"
   alias {
     name = "dmc54lz5wkr6w.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -973,7 +973,7 @@ resource "aws_route53_record" "18f_gov_paid-leave-prototype_18f_gov_a" {
   type = "A"
   alias {
     name = "d36xmdc11fynpu.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -984,7 +984,7 @@ resource "aws_route53_record" "18f_gov_partnership-playbook_18f_gov_a" {
   type = "A"
   alias {
     name = "dqd8t6xkgtofc.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -995,7 +995,7 @@ resource "aws_route53_record" "18f_gov_plain-language-tutorial_18f_gov_a" {
   type = "A"
   alias {
     name = "d3rznbn2s8vgba.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1006,7 +1006,7 @@ resource "aws_route53_record" "18f_gov_private-eye_18f_gov_a" {
   type = "A"
   alias {
     name = "d3asgf5hc4zmll.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1017,7 +1017,7 @@ resource "aws_route53_record" "18f_gov_product-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "d2ys0ic6txy8sy.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1063,7 +1063,7 @@ resource "aws_route53_record" "18f_gov_slides_18f_gov_a" {
   type = "A"
   alias {
     name = "d1mbkqkl20dkuc.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1082,7 +1082,7 @@ resource "aws_route53_record" "18f_gov_testing-cookbook_18f_gov_a" {
   type = "A"
   alias {
     name = "dvw4plzjsccwa.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1101,7 +1101,7 @@ resource "aws_route53_record" "18f_gov_writing-lab-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "dj4w2wq1t8v3j.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1112,7 +1112,7 @@ resource "aws_route53_record" "18f_gov_www_18f_gov_a" {
   type = "A"
   alias {
     name = "d1undivnru8ry9.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -29,7 +29,7 @@ resource "aws_route53_record" "18f_gov_18f_gov_txt" {
   name = "18f.gov."
   type = "TXT"
   ttl = 300
-  records = ["v=spf1 include:spf.mandrillapp.com ?all"]
+  records = ["${local.mandrill_spf}"]
 }
 
 resource "aws_route53_record" "18f_gov__dmarc_18f_gov_txt" {
@@ -106,7 +106,7 @@ resource "aws_route53_record" "18f_gov_mandrill__domainkey_18f_gov_txt" {
   name = "mandrill._domainkey.18f.gov."
   type = "TXT"
   ttl = 300
-  records = ["v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrLHiExVd55zd/IQ/J/mRwSRMAocV/hMB3jXwaHH36d9NaVynQFYV8NaWi69c1veUtRzGt7yAioXqLj7Z4TeEUoOLgrKsn8YnckGs9i3B3tVFB+Ch/4mPhXWiNfNdynHWBcPcbJ8kjEQ2U8y78dHZj1YeRXXVvWob2OaKynO8/lQIDAQAB;"]
+  records = ["${local.mandrill_dkim}"]
 }
 
 resource "aws_route53_record" "18f_gov_qegrzvzekq4wiompgqufe4xwmarm37lh__domainkey_18f_gov_cname" {
@@ -321,7 +321,7 @@ resource "aws_route53_record" "18f_gov_c2_18f_gov_txt" {
   name = "c2.18f.gov."
   type = "TXT"
   ttl = 60
-  records = ["v=spf1 include:spf.mandrillapp.com ?all"]
+  records = ["${local.mandrill_spf}"]
 }
 
 resource "aws_route53_record" "18f_gov_mandrill__domainkey_c2_18f_gov_txt" {
@@ -329,7 +329,7 @@ resource "aws_route53_record" "18f_gov_mandrill__domainkey_c2_18f_gov_txt" {
   name = "mandrill._domainkey.c2.18f.gov."
   type = "TXT"
   ttl = 60
-  records = ["v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrLHiExVd55zd/IQ/J/mRwSRMAocV/hMB3jXwaHH36d9NaVynQFYV8NaWi69c1veUtRzGt7yAioXqLj7Z4TeEUoOLgrKsn8YnckGs9i3B3tVFB+Ch/4mPhXWiNfNdynHWBcPcbJ8kjEQ2U8y78dHZj1YeRXXVvWob2OaKynO8/lQIDAQAB;"]
+  records = ["${local.mandrill_dkim}"]
 }
 
 resource "aws_route53_record" "18f_gov_c6769c03c29466618a6bd23b158d28a6_18f_gov_cname" {
@@ -855,7 +855,7 @@ resource "aws_route53_record" "18f_gov_micropurchase-staging_18f_gov_txt" {
   name = "micropurchase-staging.18f.gov."
   type = "TXT"
   ttl = 300
-  records = ["v=spf1 include:spf.mandrillapp.com ?all"]
+  records = ["${local.mandrill_spf}"]
 }
 
 resource "aws_route53_record" "18f_gov_mandrill__domainkey_micropurchase-staging_18f_gov_txt" {
@@ -863,7 +863,7 @@ resource "aws_route53_record" "18f_gov_mandrill__domainkey_micropurchase-staging
   name = "mandrill._domainkey.micropurchase-staging.18f.gov."
   type = "TXT"
   ttl = 300
-  records = ["v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrLHiExVd55zd/IQ/J/mRwSRMAocV/hMB3jXwaHH36d9NaVynQFYV8NaWi69c1veUtRzGt7yAioXqLj7Z4TeEUoOLgrKsn8YnckGs9i3B3tVFB+Ch/4mPhXWiNfNdynHWBcPcbJ8kjEQ2U8y78dHZj1YeRXXVvWob2OaKynO8/lQIDAQAB;"]
+  records = ["${local.mandrill_dkim}"]
 }
 
 # Configured with CDN Broker
@@ -891,7 +891,7 @@ resource "aws_route53_record" "18f_gov_micropurchase_18f_gov_txt" {
   name = "micropurchase.18f.gov."
   type = "TXT"
   ttl = 300
-  records = ["v=spf1 include:spf.mandrillapp.com ?all"]
+  records = ["${local.mandrill_spf}"]
 }
 
 resource "aws_route53_record" "18f_gov_mandrill__domainkey_micropurchase_18f_gov_txt" {
@@ -899,7 +899,7 @@ resource "aws_route53_record" "18f_gov_mandrill__domainkey_micropurchase_18f_gov
   name = "mandrill._domainkey.micropurchase.18f.gov."
   type = "TXT"
   ttl = 300
-  records = ["v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrLHiExVd55zd/IQ/J/mRwSRMAocV/hMB3jXwaHH36d9NaVynQFYV8NaWi69c1veUtRzGt7yAioXqLj7Z4TeEUoOLgrKsn8YnckGs9i3B3tVFB+Ch/4mPhXWiNfNdynHWBcPcbJ8kjEQ2U8y78dHZj1YeRXXVvWob2OaKynO8/lQIDAQAB;"]
+  records = ["${local.mandrill_dkim}"]
 }
 
 resource "aws_route53_record" "18f_gov_modularcontracting_18f_gov_a" {
@@ -1046,7 +1046,7 @@ resource "aws_route53_record" "18f_gov_requests_18f_gov_txt" {
   name = "requests.18f.gov."
   type = "TXT"
   ttl = 300
-  records = ["v=spf1 include:spf.mandrillapp.com ?all"]
+  records = ["${local.mandrill_spf}"]
 }
 
 resource "aws_route53_record" "18f_gov_mandrill__domainkey_requests_18f_gov_txt" {
@@ -1054,7 +1054,7 @@ resource "aws_route53_record" "18f_gov_mandrill__domainkey_requests_18f_gov_txt"
   name = "mandrill._domainkey.requests.18f.gov."
   type = "TXT"
   ttl = 300
-  records = ["v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrLHiExVd55zd/IQ/J/mRwSRMAocV/hMB3jXwaHH36d9NaVynQFYV8NaWi69c1veUtRzGt7yAioXqLj7Z4TeEUoOLgrKsn8YnckGs9i3B3tVFB+Ch/4mPhXWiNfNdynHWBcPcbJ8kjEQ2U8y78dHZj1YeRXXVvWob2OaKynO8/lQIDAQAB;"]
+  records = ["${local.mandrill_dkim}"]
 }
 
 resource "aws_route53_record" "18f_gov_slides_18f_gov_a" {

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -72,7 +72,7 @@ resource "aws_route53_record" "18f_gov_star_18f_gov_a" {
   type = "A"
   alias {
     name = "dualstack.cf-elb-elb-155eqjkdtn55i-611685241.us-east-1.elb.amazonaws.com."
-    zone_id = "Z35SXDOTRQ7X7K"
+    zone_id = "${local.cloud_gov_elb_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -650,7 +650,7 @@ resource "aws_route53_record" "18f_gov_grafana_18f_gov_a" {
   type = "A"
   alias {
     name = "dualstack.18f-grafana-1906882244.us-east-1.elb.amazonaws.com."
-    zone_id = "Z35SXDOTRQ7X7K"
+    zone_id = "${local.cloud_gov_elb_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -661,7 +661,7 @@ resource "aws_route53_record" "18f_gov_green_18f_gov_a" {
   type = "A"
   alias {
     name = "dualstack.cf-green-elb-1b9dvw4o0ubi0-1450531403.us-east-1.elb.amazonaws.com."
-    zone_id = "Z35SXDOTRQ7X7K"
+    zone_id = "${local.cloud_gov_elb_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -680,7 +680,7 @@ resource "aws_route53_record" "18f_gov_star_green_18f_gov_a" {
   type = "A"
   alias {
     name = "dualstack.cf-green-elb-1b9dvw4o0ubi0-1450531403.us-east-1.elb.amazonaws.com."
-    zone_id = "Z35SXDOTRQ7X7K"
+    zone_id = "${local.cloud_gov_elb_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -691,12 +691,12 @@ resource "aws_route53_record" "18f_gov_star_apps_green_18f_gov_a" {
   type = "A"
   alias {
     name = "dualstack.cf-green-elb-1b9dvw4o0ubi0-1450531403.us-east-1.elb.amazonaws.com."
-    zone_id = "Z35SXDOTRQ7X7K"
+    zone_id = "${local.cloud_gov_elb_zone_id}"
     evaluate_target_health = false
   }
 }
 
-  resource "aws_route53_record" "18f_gov_grouplet-playbook_18f_gov_a" {
+resource "aws_route53_record" "18f_gov_grouplet-playbook_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "grouplet-playbook.18f.gov."
   type = "A"
@@ -713,7 +713,7 @@ resource "aws_route53_record" "18f_gov_star_sys_green_18f_gov_a" {
   type = "A"
   alias {
     name = "dualstack.cf-green-elb-1b9dvw4o0ubi0-1450531403.us-east-1.elb.amazonaws.com."
-    zone_id = "Z35SXDOTRQ7X7K"
+    zone_id = "${local.cloud_gov_elb_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -796,7 +796,6 @@ resource "aws_route53_record" "18f_gov_join_18f_gov_cname" {
   ttl = 300
   records = ["dpjnqahvua4qy.cloudfront.net"]
 }
-
 
 resource "aws_route53_record" "18f_gov_lean-product-design_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "18f_gov_18f_gov_a" {
   type = "A"
   alias {
     name = "d1undivnru8ry9.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -72,7 +72,7 @@ resource "aws_route53_record" "18f_gov_star_18f_gov_a" {
   type = "A"
   alias {
     name = "dualstack.cf-elb-elb-155eqjkdtn55i-611685241.us-east-1.elb.amazonaws.com."
-    zone_id = "${local.cloud_gov_elb_zone_id}"
+    zone_id = "${local.elb_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -125,7 +125,7 @@ resource "aws_route53_record" "18f_gov_18franklin_18f_gov_a" {
   type = "A"
   alias {
     name = "d3n4rzfn59k0a9.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -136,7 +136,7 @@ resource "aws_route53_record" "18f_gov_accessibility_18f_gov_a" {
   type = "A"
   alias {
     name = "d3gg23ftaba0j8.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -147,7 +147,7 @@ resource "aws_route53_record" "18f_gov_ads_18f_gov_a" {
   type = "A"
   alias {
     name = "d1p50apr0w92d2.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -158,7 +158,7 @@ resource "aws_route53_record" "18f_gov_agile_18f_gov_a" {
   type = "A"
   alias {
     name = "d2zsago6kfzgka.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -169,7 +169,7 @@ resource "aws_route53_record" "18f_gov_agile-labor-categories_18f_gov_a" {
   type = "A"
   alias {
     name = "d1p2fryyhm3d02.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -188,7 +188,7 @@ resource "aws_route53_record" "18f_gov_acqstack-journeymap_18f_gov_a" {
   type = "A"
   alias {
     name = "d283vwqoe38bia.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -199,7 +199,7 @@ resource "aws_route53_record" "18f_gov_api-all-the-x_18f_gov_a" {
   type = "A"
   alias {
     name = "d32jbnyri5gz15.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -210,7 +210,7 @@ resource "aws_route53_record" "18f_gov_api-program_18f_gov_a" {
   type = "A"
   alias {
     name = "d1o273cx53rx83.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -221,7 +221,7 @@ resource "aws_route53_record" "18f_gov_api-usability-testing_18f_gov_a" {
   type = "A"
   alias {
     name = "d3u1jtugc2nkl7.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -240,7 +240,7 @@ resource "aws_route53_record" "18f_gov_atul-docker-presentation_18f_gov_a" {
   type = "A"
   alias {
     name = "dndsei0n82g4z.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -259,7 +259,7 @@ resource "aws_route53_record" "18f_gov_automated-testing-playbook_18f_gov_a" {
   type = "A"
   alias {
     name = "d77j39fvc23g2.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -270,7 +270,7 @@ resource "aws_route53_record" "18f_gov_blogging-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "d1g22yqn5yr45v.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -281,7 +281,7 @@ resource "aws_route53_record" "18f_gov_before-you-ship_18f_gov_a" {
   type = "A"
   alias {
     name = "daap61vtgsw76.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -292,7 +292,7 @@ resource "aws_route53_record" "18f_gov_boise_18f_gov_a" {
   type = "A"
   alias {
     name = "d3va9woazp7hye.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -303,7 +303,7 @@ resource "aws_route53_record" "18f_gov_brand_18f_gov_a" {
   type = "A"
   alias {
     name = "d19y688vepyspr.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -346,7 +346,7 @@ resource "aws_route53_record" "18f_gov_cap_18f_gov_a" {
   type = "A"
   alias {
     name = "dualstack.production-star-18f-gov-elb-1963420885.us-gov-west-1.elb.amazonaws.com."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.old_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -357,7 +357,7 @@ resource "aws_route53_record" "18f_gov_chandika_18f_gov_a" {
   type = "A"
   alias {
     name = "d1vqiz8w0x796c.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -384,7 +384,7 @@ resource "aws_route53_record" "18f_gov_climate-data-user-study_18f_gov_a" {
   type = "A"
   alias {
     name = "d28r76t17zvn4f.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -403,7 +403,7 @@ resource "aws_route53_record" "18f_gov_content-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "dv941ubd2f1ex.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -414,7 +414,7 @@ resource "aws_route53_record" "18f_gov_contracting-cookbook_18f_gov_a" {
   type = "A"
   alias {
     name = "d1fftyxpeen4gs.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -433,7 +433,7 @@ resource "aws_route53_record" "18f_gov_design-principles-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "d1z8htfdnj42fu.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -444,7 +444,7 @@ resource "aws_route53_record" "18f_gov_digital-acquisition-playbook_18f_gov_a" {
   type = "A"
   alias {
     name = "d1dov9wu7ayjg9.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -455,7 +455,7 @@ resource "aws_route53_record" "18f_gov_digitalaccelerator_18f_gov_a" {
   type = "A"
   alias {
     name = "dyumdy5yvu23d.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -490,7 +490,7 @@ resource "aws_route53_record" "18f_gov_eng-hiring_18f_gov_a" {
   type = "A"
   alias {
     name = "d1ju28lhpbkq84.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -525,7 +525,7 @@ resource "aws_route53_record" "18f_gov_federalist-docs_18f_gov_a" {
   type = "A"
   alias {
     name = "dryn1azf9y010.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -560,7 +560,7 @@ resource "aws_route53_record" "18f_gov_federalist-uswds-template_18f_gov_a" {
   type = "A"
   alias {
     name = "d14safpqycg0pm.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -579,7 +579,7 @@ resource "aws_route53_record" "18f_gov_fedspendingtransparency_18f_gov_a" {
   type = "A"
   alias {
     name = "dbdhg5alj9dxm.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -590,7 +590,7 @@ resource "aws_route53_record" "18f_gov_files_18f_gov_a" {
   type = "A"
   alias {
     name = "d3gawctq7ecsbu.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -609,7 +609,7 @@ resource "aws_route53_record" "18f_gov_frontend_18f_gov_a" {
   type = "A"
   alias {
     name = "d2dhxnk13yje6c.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -620,7 +620,7 @@ resource "aws_route53_record" "18f_gov_fugacious_18f_gov_a" {
   type = "A"
   alias {
     name = "d309sw0ah4sgku.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -639,7 +639,7 @@ resource "aws_route53_record" "18f_gov_govconnect_18f_gov_a" {
   type = "A"
   alias {
     name = "d1pr8zgciesx6n.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -650,7 +650,7 @@ resource "aws_route53_record" "18f_gov_grafana_18f_gov_a" {
   type = "A"
   alias {
     name = "dualstack.18f-grafana-1906882244.us-east-1.elb.amazonaws.com."
-    zone_id = "${local.cloud_gov_elb_zone_id}"
+    zone_id = "${local.elb_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -661,7 +661,7 @@ resource "aws_route53_record" "18f_gov_green_18f_gov_a" {
   type = "A"
   alias {
     name = "${local.cloud_gov_green_elb}"
-    zone_id = "${local.cloud_gov_elb_zone_id}"
+    zone_id = "${local.elb_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -680,7 +680,7 @@ resource "aws_route53_record" "18f_gov_star_green_18f_gov_a" {
   type = "A"
   alias {
     name = "${local.cloud_gov_green_elb}"
-    zone_id = "${local.cloud_gov_elb_zone_id}"
+    zone_id = "${local.elb_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -691,7 +691,7 @@ resource "aws_route53_record" "18f_gov_star_apps_green_18f_gov_a" {
   type = "A"
   alias {
     name = "${local.cloud_gov_green_elb}"
-    zone_id = "${local.cloud_gov_elb_zone_id}"
+    zone_id = "${local.elb_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -702,7 +702,7 @@ resource "aws_route53_record" "18f_gov_grouplet-playbook_18f_gov_a" {
   type = "A"
   alias {
     name = "d3ry367ji31g0v.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -713,7 +713,7 @@ resource "aws_route53_record" "18f_gov_star_sys_green_18f_gov_a" {
   type = "A"
   alias {
     name = "${local.cloud_gov_green_elb}"
-    zone_id = "${local.cloud_gov_elb_zone_id}"
+    zone_id = "${local.elb_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -724,7 +724,7 @@ resource "aws_route53_record" "18f_gov_guides_18f_gov_a" {
   type = "A"
   alias {
     name = "d1n7tjr4lotmf0.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -735,7 +735,7 @@ resource "aws_route53_record" "18f_gov_guides-template_18f_gov_a" {
   type = "A"
   alias {
     name = "d2ydp5mmbpnnqx.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -754,7 +754,7 @@ resource "aws_route53_record" "18f_gov_iaa-forms_18f_gov_a" {
   type = "A"
   alias {
     name = "d1ulaoarb8xdr6.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -765,7 +765,7 @@ resource "aws_route53_record" "18f_gov_identity-dev-docs_18f_gov_a" {
   type = "A"
   alias {
     name = "d35rhrbvrsocmo.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -776,7 +776,7 @@ resource "aws_route53_record" "18f_gov_innovation-toolkit-prototype_18f_gov_a" {
   type = "A"
   alias {
     name = "d8x9jyjnezbf9.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -803,7 +803,7 @@ resource "aws_route53_record" "18f_gov_lean-product-design_18f_gov_a" {
   type = "A"
   alias {
     name = "d2rme39iqpbarz.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -825,7 +825,7 @@ resource "aws_route53_record" "18f_gov_methods_18f_gov_a" {
   type = "A"
   alias {
     name = "d2z1u02mjhp26x.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -836,7 +836,7 @@ resource "aws_route53_record" "18f_gov_micropurchase-staging_18f_gov_a" {
   type = "A"
   alias {
     name = "d148p0zbwe5pp7.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -872,7 +872,7 @@ resource "aws_route53_record" "18f_gov_micropurchase_18f_gov_a" {
   type = "A"
   alias {
     name = "d2x6i02wsoxhfc.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -907,7 +907,7 @@ resource "aws_route53_record" "18f_gov_modularcontracting_18f_gov_a" {
   type = "A"
   alias {
     name = "d1iyte5ws3y9f8.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -942,7 +942,7 @@ resource "aws_route53_record" "18f_gov_open-source-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "d217cwkdnmo5gb.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -953,7 +953,7 @@ resource "aws_route53_record" "18f_gov_open-source-program_18f_gov_a" {
   type = "A"
   alias {
     name = "dmc54lz5wkr6w.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -972,7 +972,7 @@ resource "aws_route53_record" "18f_gov_paid-leave-prototype_18f_gov_a" {
   type = "A"
   alias {
     name = "d36xmdc11fynpu.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -983,7 +983,7 @@ resource "aws_route53_record" "18f_gov_partnership-playbook_18f_gov_a" {
   type = "A"
   alias {
     name = "dqd8t6xkgtofc.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -994,7 +994,7 @@ resource "aws_route53_record" "18f_gov_plain-language-tutorial_18f_gov_a" {
   type = "A"
   alias {
     name = "d3rznbn2s8vgba.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1005,7 +1005,7 @@ resource "aws_route53_record" "18f_gov_private-eye_18f_gov_a" {
   type = "A"
   alias {
     name = "d3asgf5hc4zmll.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1016,7 +1016,7 @@ resource "aws_route53_record" "18f_gov_product-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "d2ys0ic6txy8sy.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1027,7 +1027,7 @@ resource "aws_route53_record" "18f_gov_requests_18f_gov_a" {
   type = "A"
   alias {
     name = "dualstack.production-star-18f-gov-elb-1963420885.us-gov-west-1.elb.amazonaws.com."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.old_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1062,7 +1062,7 @@ resource "aws_route53_record" "18f_gov_slides_18f_gov_a" {
   type = "A"
   alias {
     name = "d1mbkqkl20dkuc.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1081,7 +1081,7 @@ resource "aws_route53_record" "18f_gov_testing-cookbook_18f_gov_a" {
   type = "A"
   alias {
     name = "dvw4plzjsccwa.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1100,7 +1100,7 @@ resource "aws_route53_record" "18f_gov_writing-lab-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "dj4w2wq1t8v3j.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1111,7 +1111,7 @@ resource "aws_route53_record" "18f_gov_www_18f_gov_a" {
   type = "A"
   alias {
     name = "d1undivnru8ry9.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -21,7 +21,7 @@ resource "aws_route53_record" "18f_gov_18f_gov_mx" {
   name = "18f.gov."
   type = "MX"
   ttl = 300
-  records = ["10 30288227.in1.mandrillapp.com", "20 30288227.in2.mandrillapp.com"]
+  records = ["${local.mandrill_mx}"]
 }
 
 resource "aws_route53_record" "18f_gov_18f_gov_txt" {
@@ -313,7 +313,7 @@ resource "aws_route53_record" "18f_gov_c2_18f_gov_mx" {
   name = "c2.18f.gov."
   type = "MX"
   ttl = 60
-  records = ["10 30288227.in1.mandrillapp.com", "20 30288227.in2.mandrillapp.com"]
+  records = ["${local.mandrill_mx}"]
 }
 
 resource "aws_route53_record" "18f_gov_c2_18f_gov_txt" {
@@ -846,7 +846,7 @@ resource "aws_route53_record" "18f_gov_micropurchase-staging_18f_gov_mx" {
   name = "micropurchase-staging.18f.gov."
   type = "MX"
   ttl = 300
-  records = ["10 30288227.in1.mandrillapp.com", "20 30288227.in2.mandrillapp.com"]
+  records = ["${local.mandrill_mx}"]
 }
 
 resource "aws_route53_record" "18f_gov_micropurchase-staging_18f_gov_txt" {
@@ -882,7 +882,7 @@ resource "aws_route53_record" "18f_gov_micropurchase_18f_gov_mx" {
   name = "micropurchase.18f.gov."
   type = "MX"
   ttl = 300
-  records = ["10 30288227.in1.mandrillapp.com", "20 30288227.in2.mandrillapp.com"]
+  records = ["${local.mandrill_mx}"]
 }
 
 resource "aws_route53_record" "18f_gov_micropurchase_18f_gov_txt" {
@@ -1037,7 +1037,7 @@ resource "aws_route53_record" "18f_gov_requests_18f_gov_mx" {
   name = "requests.18f.gov."
   type = "MX"
   ttl = 300
-  records = ["10 30288227.in1.mandrillapp.com", "20 30288227.in2.mandrillapp.com"]
+  records = ["${local.mandrill_mx}"]
 }
 
 resource "aws_route53_record" "18f_gov_requests_18f_gov_txt" {

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -660,7 +660,7 @@ resource "aws_route53_record" "18f_gov_green_18f_gov_a" {
   name = "green.18f.gov."
   type = "A"
   alias {
-    name = "dualstack.cf-green-elb-1b9dvw4o0ubi0-1450531403.us-east-1.elb.amazonaws.com."
+    name = "${local.cloud_gov_green_elb}"
     zone_id = "${local.cloud_gov_elb_zone_id}"
     evaluate_target_health = false
   }
@@ -679,7 +679,7 @@ resource "aws_route53_record" "18f_gov_star_green_18f_gov_a" {
   name = "*.green.18f.gov."
   type = "A"
   alias {
-    name = "dualstack.cf-green-elb-1b9dvw4o0ubi0-1450531403.us-east-1.elb.amazonaws.com."
+    name = "${local.cloud_gov_green_elb}"
     zone_id = "${local.cloud_gov_elb_zone_id}"
     evaluate_target_health = false
   }
@@ -690,7 +690,7 @@ resource "aws_route53_record" "18f_gov_star_apps_green_18f_gov_a" {
   name = "*.apps.green.18f.gov."
   type = "A"
   alias {
-    name = "dualstack.cf-green-elb-1b9dvw4o0ubi0-1450531403.us-east-1.elb.amazonaws.com."
+    name = "${local.cloud_gov_green_elb}"
     zone_id = "${local.cloud_gov_elb_zone_id}"
     evaluate_target_health = false
   }
@@ -712,7 +712,7 @@ resource "aws_route53_record" "18f_gov_star_sys_green_18f_gov_a" {
   name = "*.sys.green.18f.gov."
   type = "A"
   alias {
-    name = "dualstack.cf-green-elb-1b9dvw4o0ubi0-1450531403.us-east-1.elb.amazonaws.com."
+    name = "${local.cloud_gov_green_elb}"
     zone_id = "${local.cloud_gov_elb_zone_id}"
     evaluate_target_health = false
   }

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -37,9 +37,7 @@ resource "aws_route53_record" "18f_gov__dmarc_18f_gov_txt" {
   name = "_dmarc.18f.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=DMARC1; p=none; pct=10; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
-  ]
+  records = ["${local.dmarc_10}"]
 }
 
 resource "aws_route53_record" "18f_gov_01326251e4e9fc611488dd6bceaeba90_18f_gov_cname" {

--- a/terraform/app.gov.tf
+++ b/terraform/app.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "app_gov_app_gov_a" {
   type = "A"
   alias {
     name = "d1wh5biaq5z7yu.cloudfront.net"
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -22,7 +22,7 @@ resource "aws_route53_record" "app_gov_www_app_gov_a" {
   type = "A"
   alias {
     name = "d1wh5biaq5z7yu.cloudfront.net"
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/app.gov.tf
+++ b/terraform/app.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "app_gov_app_gov_a" {
   type = "A"
   alias {
     name = "d1wh5biaq5z7yu.cloudfront.net"
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -22,7 +22,7 @@ resource "aws_route53_record" "app_gov_www_app_gov_a" {
   type = "A"
   alias {
     name = "d1wh5biaq5z7yu.cloudfront.net"
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/app.gov.tf
+++ b/terraform/app.gov.tf
@@ -42,9 +42,7 @@ resource "aws_route53_record" "app_gov__dmarc_app_gov_txt" {
   name = "_dmarc.app.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=DMARC1; p=none; pct=10; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
-  ]
+  records = ["${local.dmarc_10}"]
 }
 
 output "app_gov_ns" {

--- a/terraform/app.gov.tf
+++ b/terraform/app.gov.tf
@@ -32,9 +32,7 @@ resource "aws_route53_record" "app_gov_app_gov_txt" {
   name = "app.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=spf1 -all"
-  ]
+  records = ["${local.spf_no_mail}"]
 }
 
 resource "aws_route53_record" "app_gov__dmarc_app_gov_txt" {

--- a/terraform/apps.gov.tf
+++ b/terraform/apps.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "apps_gov_apps_gov_a" {
   type = "A"
   alias {
     name = "d24f99alwtdu0h.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -88,7 +88,7 @@ resource "aws_route53_record" "apps_gov_www_apps_gov_a" {
   type = "A"
   alias {
     name = "d24f99alwtdu0h.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/apps.gov.tf
+++ b/terraform/apps.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "apps_gov_apps_gov_a" {
   type = "A"
   alias {
     name = "d24f99alwtdu0h.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -88,7 +88,7 @@ resource "aws_route53_record" "apps_gov_www_apps_gov_a" {
   type = "A"
   alias {
     name = "d24f99alwtdu0h.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/apps.gov.tf
+++ b/terraform/apps.gov.tf
@@ -29,9 +29,7 @@ resource "aws_route53_record" "apps_gov__dmarc_apps_gov_txt" {
   name = "_dmarc.apps.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=DMARC1; p=none; pct=10; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
-  ]
+  records = ["${local.dmarc_10}"]
 }
 
 resource "aws_route53_record" "apps_gov_7020370b93980d607416a29297f68e3b_apps_gov_cname" {

--- a/terraform/cloud.gov.tf
+++ b/terraform/cloud.gov.tf
@@ -1,5 +1,4 @@
 locals {
   cloud_gov_cloudfront_zone_id = "Z2FDTNDATAQYW2"
-  cloud_gov_elb_zone_id = "Z35SXDOTRQ7X7K"
   cloud_gov_green_elb = "dualstack.cf-green-elb-1b9dvw4o0ubi0-1450531403.us-east-1.elb.amazonaws.com."
 }

--- a/terraform/cloud.gov.tf
+++ b/terraform/cloud.gov.tf
@@ -1,4 +1,5 @@
 locals {
   cloud_gov_cloudfront_zone_id = "Z2FDTNDATAQYW2"
+  cloud_gov_elb_zone_id = "Z35SXDOTRQ7X7K"
   cloud_gov_green_elb = "dualstack.cf-green-elb-1b9dvw4o0ubi0-1450531403.us-east-1.elb.amazonaws.com."
 }

--- a/terraform/cloud.gov.tf
+++ b/terraform/cloud.gov.tf
@@ -1,0 +1,4 @@
+locals {
+  cloud_gov_cloudfront_zone_id = "Z2FDTNDATAQYW2"
+  cloud_gov_green_elb = "dualstack.cf-green-elb-1b9dvw4o0ubi0-1450531403.us-east-1.elb.amazonaws.com."
+}

--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "code_gov_apex" {
 
   alias {
     name = "dqziuvpgrykcy.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -25,7 +25,7 @@ resource "aws_route53_record" "code_gov_www" {
 
   alias {
     name = "dqziuvpgrykcy.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -37,7 +37,7 @@ resource "aws_route53_record" "staging_code_gov_a" {
 
   alias {
     name = "d3g0jy911fqt1l.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "code_gov_apex" {
 
   alias {
     name = "dqziuvpgrykcy.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -25,7 +25,7 @@ resource "aws_route53_record" "code_gov_www" {
 
   alias {
     name = "dqziuvpgrykcy.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -37,7 +37,7 @@ resource "aws_route53_record" "staging_code_gov_a" {
 
   alias {
     name = "d3g0jy911fqt1l.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/connect.gov.tf
+++ b/terraform/connect.gov.tf
@@ -12,7 +12,7 @@ resource "aws_route53_record" "connect_gov_connect_gov_a" {
 
   alias {
     name = "d1tqmxfevhun0x.cloudfront.net"
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = true
   }
 }
@@ -23,7 +23,7 @@ resource "aws_route53_record" "www_connect_gov_connect_gov_cname" {
   type = "A"
   alias {
     name = "d1tqmxfevhun0x.cloudfront.net"
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = true
   }
 }

--- a/terraform/connect.gov.tf
+++ b/terraform/connect.gov.tf
@@ -12,7 +12,7 @@ resource "aws_route53_record" "connect_gov_connect_gov_a" {
 
   alias {
     name = "d1tqmxfevhun0x.cloudfront.net"
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = true
   }
 }
@@ -23,7 +23,7 @@ resource "aws_route53_record" "www_connect_gov_connect_gov_cname" {
   type = "A"
   alias {
     name = "d1tqmxfevhun0x.cloudfront.net"
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = true
   }
 }

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "digital_gov_apex" {
 
   alias {
     name = "d2q1i25any8vwy.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -25,7 +25,7 @@ resource "aws_route53_record" "digital_gov_www" {
 
   alias {
     name = "d2q1i25any8vwy.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -37,7 +37,7 @@ resource "aws_route53_record" "demo_digital_gov_a" {
 
   alias {
     name = "d1f2igtqmwwbgm.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "digital_gov_apex" {
 
   alias {
     name = "d2q1i25any8vwy.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -25,7 +25,7 @@ resource "aws_route53_record" "digital_gov_www" {
 
   alias {
     name = "d2q1i25any8vwy.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -37,7 +37,7 @@ resource "aws_route53_record" "demo_digital_gov_a" {
 
   alias {
     name = "d1f2igtqmwwbgm.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -50,7 +50,7 @@ resource "aws_route53_record" "designsystem_digital_gov_a" {
   type = "A"
   alias {
     name = "dlu3fkwowya06.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -62,7 +62,7 @@ resource "aws_route53_record" "designsystem_digital_gov_aaaa" {
   type = "AAAA"
   alias {
     name = "dlu3fkwowya06.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -74,7 +74,7 @@ resource "aws_route53_record" "components_designsystem_digital_gov_a" {
   type = "A"
   alias {
     name = "dxngby1kewpe.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -86,7 +86,7 @@ resource "aws_route53_record" "components_designsystem_digital_gov_aaaa" {
   type = "AAAA"
   alias {
     name = "dxngby1kewpe.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -98,7 +98,7 @@ resource "aws_route53_record" "emerging_digital_gov_a" {
   type = "A"
   alias {
     name = "d2b40qcr6kbxp7.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -109,9 +109,7 @@ resource "aws_route53_record" "digital_gov_dmarc_digital_gov_txt" {
   name = "digital.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=spf1 -all"
-  ]
+  records = ["${local.spf_no_mail}"]
 }
 
 resource "aws_route53_record" "digital_gov__dmarc_digital_gov_txt" {

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -103,7 +103,7 @@ resource "aws_route53_record" "emerging_digital_gov_a" {
   }
 }
 
-# BOD 
+# BOD
 resource "aws_route53_record" "digital_gov_dmarc_digital_gov_txt" {
   zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
   name = "digital.gov."
@@ -119,9 +119,7 @@ resource "aws_route53_record" "digital_gov__dmarc_digital_gov_txt" {
   name = "_dmarc.digital.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=DMARC1; p=none; pct=100; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
-  ]
+  records = ["${local.dmarc_100}"]
 }
 
 output "digital_ns" {

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -97,7 +97,7 @@ resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_a" {
   type = "A"
   alias {
     name = "d11og6pgwhrztr.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "digitalgov_gov_apex" {
 
  alias {
    name = "d2a6ofmg0xhw1g.cloudfront.net."
-   zone_id = "Z2FDTNDATAQYW2"
+   zone_id = "${local.cloud_gov_cloudfront_zone_id}"
    evaluate_target_health = false
  }
 }
@@ -97,7 +97,7 @@ resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_a" {
   type = "A"
   alias {
     name = "d11og6pgwhrztr.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -313,7 +313,7 @@ resource "aws_route53_record" "support_digitalgov_gov_mx" {
 }
 
 
-# BOD 
+# BOD
 resource "aws_route53_record" "digitalgov_gov_dmarc_digitalgov_gov_txt" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "digitalgov.gov."

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -115,7 +115,7 @@ resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_txt" {
   name = "openopps.digitalgov.gov."
   type = "TXT"
   ttl = 300
-  records = ["v=spf1 include:spf.mandrillapp.com ?all"]
+  records = ["${local.mandrill_spf}"]
 }
 
 resource "aws_route53_record" "digitalgov_gov_mandrill__domainkey_openopps_digitalgov_gov_txt" {
@@ -123,7 +123,7 @@ resource "aws_route53_record" "digitalgov_gov_mandrill__domainkey_openopps_digit
   name = "mandrill._domainkey.openopps.digitalgov.gov."
   type = "TXT"
   ttl = 300
-  records = ["v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrLHiExVd55zd/IQ/J/mRwSRMAocV/hMB3jXwaHH36d9NaVynQFYV8NaWi69c1veUtRzGt7yAioXqLj7Z4TeEUoOLgrKsn8YnckGs9i3B3tVFB+Ch/4mPhXWiNfNdynHWBcPcbJ8kjEQ2U8y78dHZj1YeRXXVvWob2OaKynO8/lQIDAQAB;"]
+  records = ["${local.mandrill_dkim}"]
 }
 
 

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -327,9 +327,7 @@ resource "aws_route53_record" "digitalgov_gov__dmarc_digitalgov_gov_txt" {
   name = "_dmarc.digitalgov.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=DMARC1; p=none; pct=100; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
-  ]
+  records = ["${local.dmarc_100}"]
 }
 
 

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -317,9 +317,7 @@ resource "aws_route53_record" "digitalgov_gov_dmarc_digitalgov_gov_txt" {
   name = "digitalgov.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=spf1 -all"
-  ]
+  records = ["${local.spf_no_mail}"]
 }
 
 resource "aws_route53_record" "digitalgov_gov__dmarc_digitalgov_gov_txt" {

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -107,7 +107,7 @@ resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_mx" {
   name = "openopps.digitalgov.gov."
   type = "MX"
   ttl = 300
-  records = ["10	30288227.in1.mandrillapp.com", "20	30288227.in2.mandrillapp.com"]
+  records = ["${local.mandrill_mx}"]
 }
 
 resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_txt" {
@@ -267,9 +267,7 @@ resource "aws_route53_record" "digitalgov_gov_mandrill_domainkey_digitalgov_gov_
   name = "mandrill._domainkey.support.digitalgov.gov."
   type = "TXT"
   ttl = "3600"
-  records = [
-    "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrLHiExVd55zd/IQ/J/mRwSRMAocV/hMB3jXwaHH36d9NaVynQFYV8NaWi69c1veUtRzGt7yAioXqLj7Z4TeEUoOLgrKsn8YnckGs9i3B3tVFB+Ch/4mPhXWiNfNdynHWBcPcbJ8kjEQ2U8y78dHZj1YeRXXVvWob2OaKynO8/lQIDAQAB;"
-  ]
+  records = ["${local.mandrill_dkim}"]
 }
 
 # support.digitalgov.gov - TXT

--- a/terraform/everykidinapark.gov.tf
+++ b/terraform/everykidinapark.gov.tf
@@ -12,7 +12,7 @@ resource "aws_route53_record" "everykidinapark_gov_everykidinapark_gov_a" {
   type = "A"
   alias {
     name = "d356so74a5xncl.cloudfront.net"
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -24,7 +24,7 @@ resource "aws_route53_record" "everykidinapark_gov_www_everykidinapark_gov_a" {
   type = "A"
   alias {
     name = "d356so74a5xncl.cloudfront.net"
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/everykidinapark.gov.tf
+++ b/terraform/everykidinapark.gov.tf
@@ -12,7 +12,7 @@ resource "aws_route53_record" "everykidinapark_gov_everykidinapark_gov_a" {
   type = "A"
   alias {
     name = "d356so74a5xncl.cloudfront.net"
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -24,7 +24,7 @@ resource "aws_route53_record" "everykidinapark_gov_www_everykidinapark_gov_a" {
   type = "A"
   alias {
     name = "d356so74a5xncl.cloudfront.net"
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/everykidinapark.gov.tf
+++ b/terraform/everykidinapark.gov.tf
@@ -60,9 +60,7 @@ resource "aws_route53_record" "everykidinapark_gov__dmarc_everykidinapark_gov_tx
   name = "_dmarc.everykidinapark.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=DMARC1; p=none; pct=10; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
-  ]
+  records = ["${local.dmarc_10}"]
 }
 
 output "everykidinapark_gov_ns" {

--- a/terraform/everykidinapark.gov.tf
+++ b/terraform/everykidinapark.gov.tf
@@ -50,9 +50,7 @@ resource "aws_route53_record" "everykidinapark_gov_everykidinapark_gov_txt" {
   name = "everykidinapark.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=spf1 -all"
-  ]
+  records = ["${local.spf_no_mail}"]
 }
 
 resource "aws_route53_record" "everykidinapark_gov__dmarc_everykidinapark_gov_txt" {

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -8,6 +8,6 @@ terraform {
   }
 }
 
-variable "cloudfront_zone_id" {
-  default = "Z33AYJ8TM3BH4J"
+locals {
+  cloudfront_zone_id = "Z33AYJ8TM3BH4J"
 }

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -19,4 +19,6 @@ locals {
 
   dmarc_10 = "v=DMARC1; p=none; pct=10; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
   dmarc_100 = "v=DMARC1; p=none; pct=100; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
+
+  spf_no_mail = "v=spf1 -all"
 }

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -9,5 +9,11 @@ terraform {
 }
 
 locals {
-  cloudfront_zone_id = "Z33AYJ8TM3BH4J"
+  // Unclear where this value comes from; presumably it's a deprecated value from AWS. -Aidan Feldman, 11/6/17
+  old_cloudfront_zone_id = "Z33AYJ8TM3BH4J"
+
+  // https://docs.aws.amazon.com/general/latest/gr/rande.html#cf_region
+  cloudfront_zone_id = "Z2FDTNDATAQYW2"
+  // https://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region
+  elb_zone_id = "Z35SXDOTRQ7X7K"
 }

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -16,4 +16,7 @@ locals {
   cloudfront_zone_id = "Z2FDTNDATAQYW2"
   // https://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region
   elb_zone_id = "Z35SXDOTRQ7X7K"
+
+  dmarc_10 = "v=DMARC1; p=none; pct=10; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
+  dmarc_100 = "v=DMARC1; p=none; pct=100; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
 }

--- a/terraform/innovation.gov.tf
+++ b/terraform/innovation.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "innovation_gov_apex" {
 
   alias {
     name = "d2ntl68ywjm643.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -25,7 +25,7 @@ resource "aws_route53_record" "innovation_gov_www" {
 
   alias {
     name = "d2ntl68ywjm643.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -37,7 +37,7 @@ resource "aws_route53_record" "demo_innovation_gov_a" {
 
   alias {
     name = "d3am9l7wwd0yie.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/innovation.gov.tf
+++ b/terraform/innovation.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "innovation_gov_apex" {
 
   alias {
     name = "d2ntl68ywjm643.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -25,7 +25,7 @@ resource "aws_route53_record" "innovation_gov_www" {
 
   alias {
     name = "d2ntl68ywjm643.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -37,7 +37,7 @@ resource "aws_route53_record" "demo_innovation_gov_a" {
 
   alias {
     name = "d3am9l7wwd0yie.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/innovation.gov.tf
+++ b/terraform/innovation.gov.tf
@@ -48,9 +48,7 @@ resource "aws_route53_record" "innovation_gov_dmarc_innovation_gov_txt" {
   name = "innovation.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=spf1 -all"
-  ]
+  records = ["${local.spf_no_mail}"]
 }
 
 resource "aws_route53_record" "innovation_gov__dmarc_innovation_gov_txt" {

--- a/terraform/innovation.gov.tf
+++ b/terraform/innovation.gov.tf
@@ -42,7 +42,7 @@ resource "aws_route53_record" "demo_innovation_gov_a" {
   }
 }
 
-# BOD 
+# BOD
 resource "aws_route53_record" "innovation_gov_dmarc_innovation_gov_txt" {
   zone_id = "${aws_route53_zone.innovation_toplevel.zone_id}"
   name = "innovation.gov."
@@ -58,9 +58,7 @@ resource "aws_route53_record" "innovation_gov__dmarc_innovation_gov_txt" {
   name = "_dmarc.innovation.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=DMARC1; p=none; pct=100; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
-  ]
+  records = ["${local.dmarc_100}"]
 }
 
 output "innovation_ns" {

--- a/terraform/mandrill.tf
+++ b/terraform/mandrill.tf
@@ -1,0 +1,5 @@
+locals {
+  mandrill_dkim = "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrLHiExVd55zd/IQ/J/mRwSRMAocV/hMB3jXwaHH36d9NaVynQFYV8NaWi69c1veUtRzGt7yAioXqLj7Z4TeEUoOLgrKsn8YnckGs9i3B3tVFB+Ch/4mPhXWiNfNdynHWBcPcbJ8kjEQ2U8y78dHZj1YeRXXVvWob2OaKynO8/lQIDAQAB;"
+
+  mandrill_spf = "v=spf1 include:spf.mandrillapp.com ?all"
+}

--- a/terraform/mandrill.tf
+++ b/terraform/mandrill.tf
@@ -1,5 +1,10 @@
 locals {
   mandrill_dkim = "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrLHiExVd55zd/IQ/J/mRwSRMAocV/hMB3jXwaHH36d9NaVynQFYV8NaWi69c1veUtRzGt7yAioXqLj7Z4TeEUoOLgrKsn8YnckGs9i3B3tVFB+Ch/4mPhXWiNfNdynHWBcPcbJ8kjEQ2U8y78dHZj1YeRXXVvWob2OaKynO8/lQIDAQAB;"
 
+  mandrill_mx = [
+    "10 30288227.in1.mandrillapp.com",
+    "20 30288227.in2.mandrillapp.com"
+  ]
+
   mandrill_spf = "v=spf1 include:spf.mandrillapp.com ?all"
 }

--- a/terraform/pif.gov.tf
+++ b/terraform/pif.gov.tf
@@ -39,9 +39,7 @@ resource "aws_route53_record" "pif_gov__dmarc_pif_gov_txt" {
   name = "_dmarc.pif.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=DMARC1; p=none; pct=10; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
-  ]
+  records = ["${local.dmarc_10}"]
 }
 
 resource "aws_route53_record" "paygap_slack_cname" {

--- a/terraform/pif.gov.tf
+++ b/terraform/pif.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "www" {
 
   alias {
     name = "dgevgiwb7xxpw.cloudfront.net"
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -147,7 +147,7 @@ resource "aws_route53_record" "www-main" {
 
   alias {
     name = "dgevgiwb7xxpw.cloudfront.net"
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/pif.gov.tf
+++ b/terraform/pif.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "www" {
 
   alias {
     name = "dgevgiwb7xxpw.cloudfront.net"
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -147,7 +147,7 @@ resource "aws_route53_record" "www-main" {
 
   alias {
     name = "dgevgiwb7xxpw.cloudfront.net"
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/plainlanguage.gov.tf
+++ b/terraform/plainlanguage.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "plainlanguage_apex" {
 
   alias {
     name = "d1qy5q7pncs690.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -25,7 +25,7 @@ resource "aws_route53_record" "plainlanguage_www" {
 
   alias {
     name = "d1qy5q7pncs690.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -37,7 +37,7 @@ resource "aws_route53_record" "demo_plainlanguage_a" {
 
   alias {
     name = "d18mn70cbq9e90.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/plainlanguage.gov.tf
+++ b/terraform/plainlanguage.gov.tf
@@ -67,15 +67,13 @@ resource "aws_route53_record" "plainlanguage_google_txt" {
   ]
 }
 
-# BOD 
+# BOD
 resource "aws_route53_record" "plainlanguage_gov__dmarc_plainlanguage_gov_txt" {
   zone_id = "${aws_route53_zone.plainlanguage_toplevel.zone_id}"
   name = "_dmarc.plainlanguage.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=DMARC1; p=none; pct=10; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
-  ]
+  records = ["${local.dmarc_10}"]
 }
 
 output "plainlanguage_ns" {

--- a/terraform/presidentialinnovationfellows.gov.tf
+++ b/terraform/presidentialinnovationfellows.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "presidentialinnovationfellows_www" {
 
   alias {
     name = "d26prp92rpqmzl.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -25,7 +25,7 @@ resource "aws_route53_record" "presidentialinnovationfellows_apex" {
 
   alias {
     name = "d26prp92rpqmzl.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/presidentialinnovationfellows.gov.tf
+++ b/terraform/presidentialinnovationfellows.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "presidentialinnovationfellows_www" {
 
   alias {
     name = "d26prp92rpqmzl.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -25,7 +25,7 @@ resource "aws_route53_record" "presidentialinnovationfellows_apex" {
 
   alias {
     name = "d26prp92rpqmzl.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/presidentialinnovationfellows.gov.tf
+++ b/terraform/presidentialinnovationfellows.gov.tf
@@ -51,9 +51,7 @@ resource "aws_route53_record" "presidentialinnovationfellows__dmarc_presidential
   name = "_dmarc.presidentialinnovationfellows.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=DMARC1; p=none; pct=10; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
-  ]
+  records = ["${local.dmarc_10}"]
 }
 
 resource "aws_route53_record" "presidentialinnovationfellows_amazonses" {

--- a/terraform/transition.fec.gov.tf
+++ b/terraform/transition.fec.gov.tf
@@ -28,7 +28,7 @@ resource "aws_route53_record" "transition_gov_transition_gov_cname" {
   type = "A"
   alias {
     name = "d2p6ccc3xlipxg.cloudfront.net"
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -39,7 +39,7 @@ resource "aws_route53_record" "www_fec_gov_a_alias" {
   type = "A"
   alias {
     name = "d3t5a36r5g3qx4.cloudfront.net"
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/transition.fec.gov.tf
+++ b/terraform/transition.fec.gov.tf
@@ -28,7 +28,7 @@ resource "aws_route53_record" "transition_gov_transition_gov_cname" {
   type = "A"
   alias {
     name = "d2p6ccc3xlipxg.cloudfront.net"
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -39,7 +39,7 @@ resource "aws_route53_record" "www_fec_gov_a_alias" {
   type = "A"
   alias {
     name = "d3t5a36r5g3qx4.cloudfront.net"
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/usa.gov.tf
+++ b/terraform/usa.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "usa_gov_analytics_usa_gov_a" {
   type = "A"
   alias {
     name = "dkm80j4hktly2.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -22,7 +22,7 @@ resource "aws_route53_record" "usa_gov_analytics_usa_gov_aaaa" {
   type = "AAAA"
   alias {
     name = "dkm80j4hktly2.cloudfront.net."
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/usa.gov.tf
+++ b/terraform/usa.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "usa_gov_analytics_usa_gov_a" {
   type = "A"
   alias {
     name = "dkm80j4hktly2.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -22,7 +22,7 @@ resource "aws_route53_record" "usa_gov_analytics_usa_gov_aaaa" {
   type = "AAAA"
   alias {
     name = "dkm80j4hktly2.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/usa.gov.tf
+++ b/terraform/usa.gov.tf
@@ -1,3 +1,7 @@
+locals {
+  usa_gov_redirect_server = "54.85.132.205"
+}
+
 resource "aws_route53_zone" "usa_gov_zone" {
   name = "usa.gov."
   tags {
@@ -28,26 +32,20 @@ resource "aws_route53_record" "usa_gov_analytics_usa_gov_aaaa" {
 }
 
 # USWDS ------------------------------------------------
-# Pointing at the USA.gov redirect server
 resource "aws_route53_record" "usa_gov_components_standards_usa_gov_a" {
   zone_id = "${aws_route53_zone.usa_gov_zone.zone_id}"
   name = "components.standards.usa.gov."
   type = "A"
   ttl = "300"
-  records = [
-    "54.85.132.205"
-  ]
+  records = ["${local.usa_gov_redirect_server}"]
 }
 
-# Pointing at the USA.gov redirect server
 resource "aws_route53_record" "usa_gov_standards_usa_gov_a" {
   zone_id = "${aws_route53_zone.usa_gov_zone.zone_id}"
   name = "standards.usa.gov."
   type = "A"
   ttl = "300"
-  records = [
-    "54.85.132.205"
-  ]
+  records = ["${local.usa_gov_redirect_server}"]
 }
 
 output "usa_gov_ns" {

--- a/terraform/vote.gov.tf
+++ b/terraform/vote.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "vote_gov_vote_gov_a" {
   type = "A"
   alias {
     name = "d2s5gzwyabrtbd.cloudfront.net"
-    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/vote.gov.tf
+++ b/terraform/vote.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "vote_gov_vote_gov_a" {
   type = "A"
   alias {
     name = "d2s5gzwyabrtbd.cloudfront.net"
-    zone_id = "Z2FDTNDATAQYW2"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/vote.gov.tf
+++ b/terraform/vote.gov.tf
@@ -62,9 +62,7 @@ resource "aws_route53_record" "vote_gov__dmarc_vote_gov_txt" {
   name = "_dmarc.vote.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=DMARC1; p=none; pct=100; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
-  ]
+  records = ["${local.dmarc_100}"]
 }
 
 output "vote_gov_ns" {

--- a/terraform/vote.gov.tf
+++ b/terraform/vote.gov.tf
@@ -37,7 +37,7 @@ resource "aws_route53_record" "vote_gov_www_vote_gov_a" {
   name = "www.vote.gov."
   type = "A"
   ttl = 120
-  records = ["54.85.132.205"]
+  records = ["${local.usa_gov_redirect_server}"]
 }
 
 resource "aws_route53_record" "new_vote_gov_cname" {

--- a/terraform/vote.gov.tf
+++ b/terraform/vote.gov.tf
@@ -21,7 +21,7 @@ resource "aws_route53_record" "vote_gov_vote_gov_txt" {
   name = "vote.gov."
   type = "TXT"
   ttl = 300
-  records = ["v=spf1 -all", "blitz=mu-cbb11232-c5e05a4b-b13f3a3c-060b48f0"]
+  records = ["${local.spf_no_mail}", "blitz=mu-cbb11232-c5e05a4b-b13f3a3c-060b48f0"]
 }
 
 resource "aws_route53_record" "vote_gov_01872332dafeeb93b927e2d9e9b2c53d_vote_gov_cname" {


### PR DESCRIPTION
Builds on #151.

I've been noticing a lot of magic values that appear multiple places throughout the Terraform files, and am never really sure what they correspond to. Converting them to local values means we can have those magic constants defined only once, and name them something meaningful.

This is admittedly a fairly major refactoring, involving a lot of find-and-replace. I mostly changed one thing per commit, so may be easiest to step through them one-by-one to review. Because this pull request is touching so many critical parts of our DNS code, **I suggest running a `terraform plan` on this branch and confirming that there's no meaningful change before merging**, so that I don't take down all of TTS 😛 

The one difference I _would_ expect to see in the `plan`/`apply` is a slight change to some of the Mandrill MX records: they didn't have consistent spacing between the preference value and the mail server address. That shouldn't make a difference though.

Just FYI, I found the commonly-occurring strings using the following shell command:

```sh
grep -Eo --no-filename '["].*["]' terraform/* | sort | uniq -c | sort | tail -n 50
```