### PR TITLE
Adding the FedRAMP site to Route53

### DIFF
--- a/terraform/fedramp.gov.tf
+++ b/terraform/fedramp.gov.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_zone" "fedramp_toplevel" {
+  name = "fedramp.gov"
+
+  tags {
+    Project = "dns"
+  }
+}
+
+resource "aws_route53_record" "demo_fedramp_gov_a" {
+  zone_id = "${aws_route53_zone.fedramp_toplevel.zone_id}"
+  name = "demo.fedramp.gov."
+  type = "A"
+
+  alias {
+    name = "XXXXXXXXXXXXXXX."
+    zone_id = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}
+
+output "fedramp_ns" {
+  value="${aws_route53_zone.fedramp_toplevel.name_servers}"
+}

--- a/terraform/fedramp.gov.tf
+++ b/terraform/fedramp.gov.tf
@@ -12,7 +12,7 @@ resource "aws_route53_record" "demo_fedramp_gov_a" {
   type = "A"
 
   alias {
-    name = "XXXXXXXXXXXXXXX."
+    name = "d11q09ta0k47w4.cloudfront.net."
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
   }


### PR DESCRIPTION
This is a placeholder till we get the Cloudfront URLs

PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.
