### PR TITLE
add TXT record to prove ownership of fugacious.18f.gov

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -615,6 +615,14 @@ resource "aws_route53_record" "18f_gov_fugacious_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "18f_gov_fugacious_18f_gov_txt" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "fugacious.18f.gov."
+  type = "TXT"
+  ttl = 300
+  records = ["dbifnpoekiab5.cloudfront.net."]
+}
+
 resource "aws_route53_record" "18f_gov_govconnect_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "govconnect.18f.gov."
@@ -677,7 +685,7 @@ resource "aws_route53_record" "18f_gov_star_apps_green_18f_gov_a" {
     evaluate_target_health = false
   }
 }
-  
+
   resource "aws_route53_record" "18f_gov_grouplet-playbook_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "grouplet-playbook.18f.gov."
@@ -908,7 +916,7 @@ resource "aws_route53_record" "18f_gov_e02bc03821dff6c0c958b96ad4476517_munki_18
   ttl = 5
   records = ["d3a976c8a19db425a0b6fab24f793df8c0341d67.comodoca.com."]
 }
-  
+
 resource "aws_route53_record" "18f_gov_open-source-guide_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "open-source-guide.18f.gov."
@@ -930,7 +938,7 @@ resource "aws_route53_record" "18f_gov_open-source-program_18f_gov_a" {
     evaluate_target_health = false
   }
 }
-  
+
 resource "aws_route53_record" "18f_gov_openopps-staging_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "openopps-staging.18f.gov."
@@ -1008,7 +1016,7 @@ resource "aws_route53_record" "18f_gov_pages_18f_gov_cname" {
   ttl = 300
   records = ["dvtze1xj8nrwl.cloudfront.net"]
 }
-  
+
 resource "aws_route53_record" "18f_gov_paid-leave-prototype_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "paid-leave-prototype.18f.gov."
@@ -1041,7 +1049,7 @@ resource "aws_route53_record" "18f_gov_plain-language-tutorial_18f_gov_a" {
     evaluate_target_health = false
   }
 }
-  
+
 resource "aws_route53_record" "18f_gov_private-eye_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "private-eye.18f.gov."


### PR DESCRIPTION
Following instructions at
https://aws.amazon.com/premiumsupport/knowledge-center/resolve-cnamealreadyexists-error/.