### PR TITLE
Add records to support Google Groups

### DIFF
--- a/terraform/plainlanguage.gov.tf
+++ b/terraform/plainlanguage.gov.tf
@@ -42,6 +42,36 @@ resource "aws_route53_record" "demo_plainlanguage_a" {
   }
 }
 
+resource "aws_route53_record" "plainlanguage_google_mx" {
+    name = "plainlanguage.gov."
+    records = [
+        "1 aspmx.l.google.com.",
+        "5 alt1.aspmx.l.google.com.",
+        "5 alt2.aspmx.l.google.com.",
+        "10 alt3.aspmx.l.google.com.",
+        "10 alt4.aspmx.l.google.com."
+    ]
+    ttl = "300"
+    type = "MX"
+    zone_id = "${aws_route53_zone.plainlanguage_toplevel.zone_id}"
+}
+
+resource "aws_route53_record" "plainlanguage_google_txt" {
+  zone_id = "${aws_route53_zone.plainlanguage_toplevel.zone_id}"
+  name = "plainlanguage.gov"
+  type = "TXT"
+  ttl = 600
+  records = ["google-site-verification=dgYaMRA2hd9PDUV1zEcRyWmTOVZCbkbP3vXd4isEZLI"]
+}
+
+resource "aws_route53_record" "plainlanguage_v_txt" {
+  zone_id = "${aws_route53_zone.plainlanguage_toplevel.zone_id}"
+  name = "plainlanguage.gov"
+  type = "TXT"
+  ttl = 600
+  records = ["v=spf1 include:_spf.google.com include:spf_sa.gsa.gov ~all"]
+}
+
 output "plainlanguage_ns" {
   value="${aws_route53_zone.plainlanguage_toplevel.name_servers}"
 }


### PR DESCRIPTION
These records will allow the plainlanguage.gov domain to be used with Google Groups. The values were provided to me by GSA IT. The `google-site-verification` `TXT` value is required in order to add the domain to GSA Google Apps, the others (`MX`, `SPF`) are in support of email delivery.

PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.
