### PR TITLE
SPF/DMARC Reject Update

### DIFF
--- a/terraform/everykidinapark.gov.tf
+++ b/terraform/everykidinapark.gov.tf
@@ -55,7 +55,7 @@ resource "aws_route53_record" "everykidinapark_gov_everykidinapark_gov_txt" {
   ]
 }
 
-resource "aws_route53_record" "everykidinapark_gov_everykidinapark_gov_txt" {
+resource "aws_route53_record" "everykidinapark_gov_dmarc_everykidinapark_gov_txt" {
   zone_id = "${aws_route53_zone.everykidinapark_gov_zone.zone_id}"
   name = "_dmarc.everykidinapark.gov."
   type = "TXT"

--- a/terraform/everykidinapark.gov.tf
+++ b/terraform/everykidinapark.gov.tf
@@ -55,7 +55,7 @@ resource "aws_route53_record" "everykidinapark_gov_everykidinapark_gov_txt" {
   ]
 }
 
-resource "aws_route53_record" "everykidinapark_gov_dmarc_everykidinapark_gov_txt" {
+resource "aws_route53_record" "everykidinapark_gov__dmarc_everykidinapark_gov_txt" {
   zone_id = "${aws_route53_zone.everykidinapark_gov_zone.zone_id}"
   name = "_dmarc.everykidinapark.gov."
   type = "TXT"

--- a/terraform/everykidinapark.gov.tf
+++ b/terraform/everykidinapark.gov.tf
@@ -51,7 +51,16 @@ resource "aws_route53_record" "everykidinapark_gov_everykidinapark_gov_txt" {
   type = "TXT"
   ttl = 300
   records = [
-     "v=spf1 -all",
+     "v=spf1 -all"
+  ]
+}
+
+resource "aws_route53_record" "everykidinapark_gov_everykidinapark_gov_txt" {
+  zone_id = "${aws_route53_zone.everykidinapark_gov_zone.zone_id}"
+  name = "_dmarc.everykidinapark.gov."
+  type = "TXT"
+  ttl = 300
+  records = [
      "v=DMARC1; p=reject; rua=dmarcreports@gsa.gov; ruf=dmarcfailures@gsa.gov; fo=1; ri=86400"
   ]
 }


### PR DESCRIPTION
Split the SPF and DMARC Reject records since only one was being returned.

PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.
