### PR TITLE
adding api.code.gov cname

### DIFF
--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -42,6 +42,15 @@ resource "aws_route53_record" "staging_code_gov_a" {
   }
 }
 
+resource "aws_route53_record" "code_gov_api_cname" {
+  zone_id = "${aws_route53_zone.code_toplevel.zone_id}"
+  name = "api.code.gov."
+  type = "CNAME"
+  ttl = 300
+  records = ["api-code-gov.domains.api.data.gov"]
+}
+
+
 output "code_ns" {
   value="${aws_route53_zone.code_toplevel.name_servers}"
 }


### PR DESCRIPTION
Setting up api.data.gov for the code.gov api.  The need is for `api.code.gov` to be CNAMED to `api-code-gov.domains.api.data.gov`.  More details [here](https://github.com/GSA/code-gov-api/issues/134) and [background how-to](https://github.com/18F/api.data.gov/wiki/User-Manual:-Agencies#using-your-own-domain-name).  

_PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team._

