### PR TITLE
remove AAAA record for openopps

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -17,23 +17,12 @@ resource "aws_route53_record" "www_digitalgov_gov_digitalgov_gov_a" {
   }
 }
 
-resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_a" {
+resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_cname" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "openopps.digitalgov.gov."
   type = "CNAME"
   ttl = "300"
   records = ["openopps.usajobs.gov."]
-}
-
-resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_aaaa" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name = "openopps.digitalgov.gov."
-  type = "AAAA"
-  alias {
-    name = "d11og6pgwhrztr.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
 }
 
 resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_mx" {


### PR DESCRIPTION
Follow-up to #165. This should fix [the error in Concourse](https://concourse-ci.fr.cloud.gov/teams/gsa-tts-infrastructure/pipelines/dns-prod/jobs/dns-prod/builds/154?):

```
Error: Error applying plan:

1 error(s) occurred:

* aws_route53_record.digitalgov_gov_openopps_digitalgov_gov_a: 1 error(s) occurred:

* aws_route53_record.digitalgov_gov_openopps_digitalgov_gov_a: [ERR]: Error building changeset: InvalidChangeBatch: RRSet of type CNAME with DNS name openopps.digitalgov.gov. is not permitted as it conflicts with other records with the same DNS name in zone digitalgov.gov.
	status code: 400, request id: 40f68032-e5bf-11e7-97bf-33bc193ec56b
```