### PR TITLE
Fixing R53 Errors in the digitalgov.gov Terraform file

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -84,11 +84,6 @@ resource "aws_route53_record" "usdigitalregistry_digitalgov_gov_a" {
   records = [
     "gsa-elb-ecs-prod-wild-diggov-1-1458076956.us-east-1.elb.amazonaws.com."
   ]
-  alias {
-    name = "gsa-elb-ecs-prod-wild-diggov-1-1458076956.us-east-1.elb.amazonaws.com."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
 }
 
 # dap.digitalgov.gov

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -1,4 +1,4 @@
-resource "aws_route53_zone" "digitalgov_gov_toplevel" {
+resource "aws_route53_zone" "digitalgov_gov_zone" {
   name = "digitalgov.gov."
   tags {
     Project = "dns"
@@ -7,7 +7,7 @@ resource "aws_route53_zone" "digitalgov_gov_toplevel" {
 
 # digitalgov.gov
 resource "aws_route53_record" "digitalgov_gov_apex" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "digitalgov.gov."
   type = "A"
 
@@ -20,46 +20,39 @@ resource "aws_route53_record" "digitalgov_gov_apex" {
 
 # o166.email.digitalgov.gov — A
 resource "aws_route53_record" "o166_email_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "o166.email.digitalgov.gov."
   type = "A"
-
-  alias {
-    name = "167.89.86.190"
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
+  records = [
+    "167.89.86.190"
+  ]
 }
 
 # admin.digitalgov.gov — A
 resource "aws_route53_record" "admin_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "admin.digitalgov.gov."
   type = "A"
-
-  alias {
-    name = "173.203.40.168"
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
+  records = [
+    "173.203.40.168"
+  ]
 }
 
-# email.digitalgov.gov — A
-resource "aws_route53_record" "email_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
-  name = "admin.digitalgov.gov."
+# support.digitalgov.gov — A
+resource "aws_route53_record" "support_digitalgov_gov_a" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "support.digitalgov.gov."
   type = "A"
-
-  alias {
-    name = "216.128.241.47, 173.252.148.104"
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
+  ttl = "600"
+  records = [
+    "216.128.241.47",
+    "173.252.148.104",
+  ]
 }
 
 # www.digitalgov.gov
 resource "aws_route53_record" "digitalgov_gov_www" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "www.digitalgov.gov."
   type = "CNAME"
 
@@ -72,7 +65,7 @@ resource "aws_route53_record" "digitalgov_gov_www" {
 
 # demo.digitalgov.gov
 resource "aws_route53_record" "demo_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "demo.digitalgov.gov."
   type = "CNAME"
 
@@ -85,10 +78,12 @@ resource "aws_route53_record" "demo_digitalgov_gov_a" {
 
 # usdigitalregistry.digitalgov.gov
 resource "aws_route53_record" "usdigitalregistry_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "usdigitalregistry.digitalgov.gov."
   type = "CNAME"
-
+  records = [
+    "gsa-elb-ecs-prod-wild-diggov-1-1458076956.us-east-1.elb.amazonaws.com."
+  ]
   alias {
     name = "gsa-elb-ecs-prod-wild-diggov-1-1458076956.us-east-1.elb.amazonaws.com."
     zone_id = "Z2FDTNDATAQYW2"
@@ -98,73 +93,58 @@ resource "aws_route53_record" "usdigitalregistry_digitalgov_gov_a" {
 
 # dap.digitalgov.gov
 resource "aws_route53_record" "dap_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "dap.digitalgov.gov."
   type = "CNAME"
-
-  alias {
-    name = "www.usa.gov.edgekey.net."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
+  records = [
+    "www.usa.gov.edgekey.net."
+  ]
 }
 
 # search.digitalgov.gov
 resource "aws_route53_record" "search_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "search.digitalgov.gov."
   type = "CNAME"
-
-  alias {
-    name = "dgsearchsite.infr.search.usa.gov."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
+  records = [
+    "dgsearchsite.infr.search.usa.gov."
+  ]
 }
 
 # summit.digitalgov.gov
 resource "aws_route53_record" "summit_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "summit.digitalgov.gov."
   type = "CNAME"
-
-  alias {
-    name = "www.usa.gov.edgekey.net."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
+  records = [
+    "www.usa.gov.edgekey.net."
+  ]
 }
 
 # connect.digitalgov.gov
 resource "aws_route53_record" "connect_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "connect.digitalgov.gov."
   type = "CNAME"
-
-  alias {
-    name = "1962994g44.secure0082.hubspot.net."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
+  records = [
+    "1962994g44.secure0082.hubspot.net."
+  ]
 }
 
 # find.digitalgov.gov
 resource "aws_route53_record" "find_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "find.digitalgov.gov."
   type = "CNAME"
-
-  alias {
-    name = "digitalgov.sites.infr.search.usa.gov."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
+  records = [
+    "digitalgov.sites.infr.search.usa.gov."
+  ]
 }
 
 # stage-socialmobileregistry.digitalgov.gov
 resource "aws_route53_record" "stage-socialmobileregistry_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
-  name = "gsa-elb-ecs-stg-wild-diggov-1-1092638291.us-east-1.elb.amazonaws.com."
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "stage-socialmobileregistry."
   type = "CNAME"
 
   alias {
@@ -176,15 +156,12 @@ resource "aws_route53_record" "stage-socialmobileregistry_digitalgov_gov_a" {
 
 # k1._domainkey.support.digitalgov.gov — CNAME
 resource "aws_route53_record" "k1_domainkey_support_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "k1._domainkey.support.digitalgov.gov."
   type = "CNAME"
-
-  alias {
-    name = "dkim.mcsv.net."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
+  records = [
+    "dkim.mcsv.net."
+  ]
 }
 
 
@@ -194,66 +171,42 @@ resource "aws_route53_record" "k1_domainkey_support_digitalgov_gov_a" {
 
 # openopps.digitalgov.gov - NS
 resource "aws_route53_record" "digitalgov_gov_openopps_25_digitalgov_gov_ns" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "openopps.digitalgov.gov."
   type = "NS"
-  alias {
-    name = "ns-1231.awsdns-25.org."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
+  records = [
+    "ns-1231.awsdns-25.org."
+  ]
 }
 
 # openopps.digitalgov.gov - NS
 resource "aws_route53_record" "digitalgov_gov_openopps_56_digitalgov_gov_ns" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "openopps.digitalgov.gov."
   type = "NS"
-  alias {
-    name = "ns-452.awsdns-56.com."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
+  records = [
+    "ns-452.awsdns-56.com."
+  ]
 }
 
 # openopps.digitalgov.gov - NS
 resource "aws_route53_record" "digitalgov_gov_openopps_34_digitalgov_gov_ns" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "openopps.digitalgov.gov."
   type = "NS"
-  alias {
-    name = "ns-788.awsdns-34.net."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
+  records = [
+    "ns-788.awsdns-34.net."
+  ]
 }
 
 # openopps.digitalgov.gov - NS
 resource "aws_route53_record" "digitalgov_gov_openopps_43_digitalgov_gov_ns" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "openopps.digitalgov.gov."
   type = "NS"
-  alias {
-    name = "ns-1886.awsdns-43.co.uk."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
-}
-
-
-# ==========
-# SPF Records
-
-# support.digitalgov.gov - SPF
-resource "aws_route53_record" "digitalgov_gov_support_digitalgov_gov_spf" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
-  name = "support.digitalgov.gov."
-  type = "SPF"
-  alias {
-    name = "v=spf1 include:spf.mandrillapp.com include:mail.zendesk.com include:emailsrvr.com include:servers.mcsv.net ~all"
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
+  records = [
+    "ns-1886.awsdns-43.co.uk."
+  ]
 }
 
 
@@ -261,12 +214,12 @@ resource "aws_route53_record" "digitalgov_gov_support_digitalgov_gov_spf" {
 # ==========
 # TXT Records
 
-
 # dzc.digitalgov.gov - TXT
 resource "aws_route53_record" "digitalgov_gov_dzc_digitalgov_gov_txt" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "dzc.digitalgov.gov."
   type = "TXT"
+  ttl = "300"
   records = [
     "8wtx7v9M"
   ]
@@ -274,7 +227,7 @@ resource "aws_route53_record" "digitalgov_gov_dzc_digitalgov_gov_txt" {
 
 # email.digitalgov.gov - TXT
 resource "aws_route53_record" "digitalgov_gov_email_digitalgov_gov_txt" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "email.digitalgov.gov."
   type = "TXT"
   ttl = "3600"
@@ -285,9 +238,10 @@ resource "aws_route53_record" "digitalgov_gov_email_digitalgov_gov_txt" {
 
 # m1._domainkey.digitalgov.gov - TXT
 resource "aws_route53_record" "digitalgov_gov_m1_domainkey_digitalgov_gov_txt" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "m1._domainkey.digitalgov.gov."
   type = "TXT"
+  ttl = "300"
   records = [
     "k=rsa; t=s; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC4CvMOSVFOQDIJ+HkjdfAmKuBkkiqTwV982PCFBocVGHY07N2uvkleqT+XrySENYYzFrdnk2U1I7HUYkA0tpEZNzU7G67l7u1qWcd5QMBzVDsAg2vJf4fAkAWmdQCyWboeVXCoMnswz5LZK/t0+Z37smv9k2nDK3XNdsYTVu8D8wIDAQAB"
   ]
@@ -295,7 +249,7 @@ resource "aws_route53_record" "digitalgov_gov_m1_domainkey_digitalgov_gov_txt" {
 
 # mandrill._domainkey.support.digitalgov.gov - TXT
 resource "aws_route53_record" "digitalgov_gov_mandrill_domainkey_digitalgov_gov_txt" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "mandrill._domainkey.support.digitalgov.gov."
   type = "TXT"
   ttl = "3600"
@@ -306,7 +260,7 @@ resource "aws_route53_record" "digitalgov_gov_mandrill_domainkey_digitalgov_gov_
 
 # support.digitalgov.gov - TXT
 resource "aws_route53_record" "digitalgov_gov_support_digitalgov_gov_txt" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "support.digitalgov.gov."
   type = "TXT"
   ttl = "3600"
@@ -324,7 +278,7 @@ resource "aws_route53_record" "digitalgov_gov_support_digitalgov_gov_txt" {
 
 # email.digitalgov.gov — MX
 resource "aws_route53_record" "email_digitalgov_gov_mx" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "email.digitalgov.gov."
   type = "MX"
   ttl = "3600"
@@ -335,7 +289,7 @@ resource "aws_route53_record" "email_digitalgov_gov_mx" {
 
 # support.digitalgov.gov — MX
 resource "aws_route53_record" "support_digitalgov_gov_mx" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_toplevel.zone_id}"
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "support.digitalgov.gov."
   type = "MX"
   ttl = "600"
@@ -345,5 +299,5 @@ resource "aws_route53_record" "support_digitalgov_gov_mx" {
 }
 
 output "digitalgov_gov_ns" {
-  value="${aws_route53_zone.digitalgov_gov_toplevel.name_servers}"
+  value="${aws_route53_zone.digitalgov_gov_zone.name_servers}"
 }


### PR DESCRIPTION
There were **19 errors** in the `digitalgov.gov` terraform file. These are fixes to those errors

**FIXED**
```
* aws_route53_record.stage-socialmobileregistry_digitalgov_gov_a: 1 error(s) occurred:
* aws_route53_record.stage-socialmobileregistry_digitalgov_gov_a: [ERR]: Error building changeset: InvalidChangeBatch: FATAL problem: DomainLabelEmpty (Domain label is empty) encountered with ‘gsa-elb-ecs-stg-wild-diggov-1-1092638291.us-east-1.elb.amazonaws.com..digitalgov.gov’
status code: 400, request id: 2cd344b0-e737-11e7-914d-21e32544f643
````

**FIXED**
```
* aws_route53_record.digitalgov_gov_m1_domainkey_digitalgov_gov_txt: 1 error(s) occurred:
* aws_route53_record.digitalgov_gov_m1_domainkey_digitalgov_gov_txt: provider.aws: aws_route53_record: m1._domainkey.digitalgov.gov.: “ttl”: required field is not set
```

**FIXED**
```
* aws_route53_record.digitalgov_gov_support_digitalgov_gov_spf: 1 error(s) occurred:
* 
* aws_route53_record.digitalgov_gov_support_digitalgov_gov_spf: [ERR]: Error building changeset: InvalidChangeBatch: FATAL problem: UnsupportedCharacter (Value contains unsupported characters) encountered with ' '
status code: 400, request id: 2dfe08ae-e737-11e7-984f-d7dc204c7439
```

**FIXED**
```
* aws_route53_record.usdigitalregistry_digitalgov_gov_a: 1 error(s) occurred:
* aws_route53_record.usdigitalregistry_digitalgov_gov_a: [ERR]: Error building changeset: InvalidChangeBatch: Tried to create an alias that targets gsa-elb-ecs-prod-wild-diggov-1-1458076956.us-east-1.elb.amazonaws.com., type CNAME in zone Z2FDTNDATAQYW2, but the alias target name does not lie within the target zone
status code: 400, request id: 2e63818c-e737-11e7-bcfa-5d69fd60b247
```

**FIXED** (removed record)
``` 
* aws_route53_record.email_digitalgov_gov_a: 1 error(s) occurred:
* aws_route53_record.email_digitalgov_gov_a: [ERR]: Error building changeset: InvalidChangeBatch: FATAL problem: UnsupportedCharacter (Value contains unsupported characters) encountered with ' '
status code: 400, request id: 3358bb30-e737-11e7-91b9-9f6e99bec84f
```

**FIXED**
```
* aws_route53_record.search_digitalgov_gov_a: 1 error(s) occurred:
* aws_route53_record.search_digitalgov_gov_a: [ERR]: Error building changeset: InvalidChangeBatch: Tried to create an alias that targets dgsearchsite.infr.search.usa.gov., type CNAME in zone Z2FDTNDATAQYW2, but the alias target name does not lie within the target zone
status code: 400, request id: 27d57f7c-e737-11e7-a51e-7b5ca9ec0245
```

**FIXED**
```
* aws_route53_record.digitalgov_gov_openopps_34_digitalgov_gov_ns: 1 error(s) occurred:
* aws_route53_record.digitalgov_gov_openopps_34_digitalgov_gov_ns: [ERR]: Error building changeset: InvalidChangeBatch: Tried to create an alias that targets ns-788.awsdns-34.net., type NS in zone Z2FDTNDATAQYW2, but the alias target name does not lie within the target zone
status code: 400, request id: 292927b3-e737-11e7-bcfa-5d69fd60b247
```

**FIXED**
```
* aws_route53_record.digitalgov_gov_openopps_43_digitalgov_gov_ns: 1 error(s) occurred:
* aws_route53_record.digitalgov_gov_openopps_43_digitalgov_gov_ns: [ERR]: Error building changeset: InvalidChangeBatch: Tried to create an alias that targets ns-1886.awsdns-43.co.uk., type NS in zone Z2FDTNDATAQYW2, but the alias target name does not lie within the target zone
status code: 400, request id: 2d8fb660-e737-11e7-8456-41d8d6fcb1f8
```

**FIXED**
```
* aws_route53_record.dap_digitalgov_gov_a: 1 error(s) occurred:
* aws_route53_record.dap_digitalgov_gov_a: [ERR]: Error building changeset: InvalidChangeBatch: Tried to create an alias that targets www.usa.gov.edgekey.net., type CNAME in zone Z2FDTNDATAQYW2, but the alias target name does not lie within the target zone
status code: 400, request id: 2feb0b88-e737-11e7-914d-21e32544f643
```

**FIXED**
``` 
* aws_route53_record.o166_email_digitalgov_gov_a: 1 error(s) occurred:
* aws_route53_record.o166_email_digitalgov_gov_a: [ERR]: Error building changeset: InvalidChangeBatch: Tried to create an alias that targets 167.89.86.190., type A in zone Z2FDTNDATAQYW2, but the alias target name does not lie within the target zone
status code: 400, request id: 2ed49232-e737-11e7-984f-d7dc204c7439
```

**FIXED**
```
* aws_route53_record.digitalgov_gov_dzc_digitalgov_gov_txt: 1 error(s) occurred:
* aws_route53_record.digitalgov_gov_dzc_digitalgov_gov_txt: provider.aws: aws_route53_record: dzc.digitalgov.gov.: “ttl”: required field is not set
```

**FIXED**
```
* aws_route53_record.k1_domainkey_support_digitalgov_gov_a: 1 error(s) occurred:
* aws_route53_record.k1_domainkey_support_digitalgov_gov_a: [ERR]: Error building changeset: InvalidChangeBatch: Tried to create an alias that targets dkim.mcsv.net., type CNAME in zone Z2FDTNDATAQYW2, but the alias target name does not lie within the target zone
status code: 400, request id: 2f727feb-e737-11e7-a51e-7b5ca9ec0245
```

**FIXED**
```
* aws_route53_record.digitalgov_gov_openopps_25_digitalgov_gov_ns: 1 error(s) occurred:
* aws_route53_record.digitalgov_gov_openopps_25_digitalgov_gov_ns: [ERR]: Error building changeset: InvalidChangeBatch: Tried to create an alias that targets ns-1231.awsdns-25.org., type NS in zone Z2FDTNDATAQYW2, but the alias target name does not lie within the target zone
status code: 400, request id: 2fe2ce19-e737-11e7-a51e-7b5ca9ec0245
```

**FIXED**
```
Changed the ZONE back to `digitalgov_gov_zone` from `digitalgov_gov_toplevel`
* aws_route53_zone.digitalgov_gov_zone (destroy): 1 error(s) occurred:
* aws_route53_zone.digitalgov_gov_zone: HostedZoneNotEmpty: The specified hosted zone contains non-required resource record sets and so cannot be deleted.
status code: 400, request id: 274cc6c4-e737-11e7-b734-5f4f8914e6f7
```

**FIXED**
```
* aws_route53_record.admin_digitalgov_gov_a: 1 error(s) occurred:
* aws_route53_record.admin_digitalgov_gov_a: [ERR]: Error building changeset: InvalidChangeBatch: Tried to create an alias that targets 173.203.40.168., type A in zone Z2FDTNDATAQYW2, but the alias target name does not lie within the target zone
status code: 400, request id: 28296b5f-e737-11e7-914d-21e32544f643
```

**FIXED**
```
* aws_route53_record.summit_digitalgov_gov_a: 1 error(s) occurred:
* aws_route53_record.summit_digitalgov_gov_a: [ERR]: Error building changeset: InvalidChangeBatch: Tried to create an alias that targets www.usa.gov.edgekey.net., type CNAME in zone Z2FDTNDATAQYW2, but the alias target name does not lie within the target zone
status code: 400, request id: 2d78d333-e737-11e7-8fb7-453cb69d51b2
```

**FIXED**
```
* aws_route53_record.find_digitalgov_gov_a: 1 error(s) occurred:
* aws_route53_record.find_digitalgov_gov_a: [ERR]: Error building changeset: InvalidChangeBatch: Tried to create an alias that targets digitalgov.sites.infr.search.usa.gov., type CNAME in zone Z2FDTNDATAQYW2, but the alias target name does not lie within the target zone
status code: 400, request id: 3054f187-e737-11e7-96dc-1fc11d8b9262
```

**FIXED**
```
* aws_route53_record.connect_digitalgov_gov_a: 1 error(s) occurred:
* aws_route53_record.connect_digitalgov_gov_a: [ERR]: Error building changeset: InvalidChangeBatch: Tried to create an alias that targets 1962994g44.secure0082.hubspot.net., type CNAME in zone Z2FDTNDATAQYW2, but the alias target name does not lie within the target zone
status code: 400, request id: 28483dc9-e737-11e7-abe2-534f123f3ec9
```


**FIXED**
```
* aws_route53_record.digitalgov_gov_openopps_56_digitalgov_gov_ns: 1 error(s) occurred:
* aws_route53_record.digitalgov_gov_openopps_56_digitalgov_gov_ns: [ERR]: Error building changeset: InvalidChangeBatch: Tried to create an alias that targets ns-452.awsdns-56.com., type NS in zone Z2FDTNDATAQYW2, but the alias target name does not lie within the target zone
status code: 400, request id: 28b30e24-e737-11e7-8fb7-453cb69d51b2
```
