### PR TITLE
Fixed two errors with the terraform file for digitalgov.gov

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -147,7 +147,7 @@ resource "aws_route53_record" "find_digitalgov_gov_a" {
 # stage-socialmobileregistry.digitalgov.gov
 resource "aws_route53_record" "stage-socialmobileregistry_digitalgov_gov_a" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name = "stage-socialmobileregistry."
+  name = "stage-socialmobileregistry.digitalgov.gov."
   type = "CNAME"
   ttl = "300"
   records = [
@@ -187,6 +187,7 @@ resource "aws_route53_record" "digitalgov_gov_openopps_56_digitalgov_gov_ns" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "openopps.digitalgov.gov."
   type = "NS"
+  ttl = "300"
   records = [
     "ns-452.awsdns-56.com."
   ]


### PR DESCRIPTION
**FIXED** — added digitalgov.gov. to the domain
```
* aws_route53_record.stage-socialmobileregistry_digitalgov_gov_a: 1 error(s) occurred:
* aws_route53_record.stage-socialmobileregistry_digitalgov_gov_a: [ERR]: Error building changeset: InvalidChangeBatch: FATAL problem: DomainLabelEmpty (Domain label is empty) encountered with 'stage-socialmobileregistry..digitalgov.gov'
status code: 400, request id: 400b4e2e-e74d-11e7-bb3d-4148ef785c9d
```

**FIXED** — added TTL
```    
* aws_route53_record.digitalgov_gov_openopps_56_digitalgov_gov_ns: 1 error(s) occurred:
* aws_route53_record.digitalgov_gov_openopps_56_digitalgov_gov_ns: provider.aws: aws_route53_record: openopps.digitalgov.gov.: "ttl": required field is not set
```

---

PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.
