### PR TITLE
Moved DAP to CloudFront. Formerly on Akamai

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -103,7 +103,7 @@ resource "aws_route53_record" "dap_digitalgov_gov_a" {
   type = "CNAME"
   ttl = "300"
   records = [
-    "www.usa.gov.edgekey.net."
+    "d27f3qgc9anoq2.cloudfront.net."
   ]
 }
 


### PR DESCRIPTION
PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.
