### PR TITLE
Changing OpenOpps CNAME

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -173,52 +173,14 @@ resource "aws_route53_record" "k1_domainkey_support_digitalgov_gov_a" {
   ]
 }
 
-
-
-# ==========
-# NS Records
-
 # openopps.digitalgov.gov - NS
-resource "aws_route53_record" "digitalgov_gov_openopps_25_digitalgov_gov_ns" {
+resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_ns" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "openopps.digitalgov.gov."
-  type = "NS"
+  type = "CNAME"
   ttl = "300"
   records = [
-    "ns-1231.awsdns-25.org."
-  ]
-}
-
-# openopps.digitalgov.gov - NS
-resource "aws_route53_record" "digitalgov_gov_openopps_56_digitalgov_gov_ns" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name = "openopps.digitalgov.gov."
-  type = "NS"
-  ttl = "300"
-  records = [
-    "ns-452.awsdns-56.com."
-  ]
-}
-
-# openopps.digitalgov.gov - NS
-resource "aws_route53_record" "digitalgov_gov_openopps_34_digitalgov_gov_ns" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name = "openopps.digitalgov.gov."
-  type = "NS"
-  ttl = "300"
-  records = [
-    "ns-788.awsdns-34.net."
-  ]
-}
-
-# openopps.digitalgov.gov - NS
-resource "aws_route53_record" "digitalgov_gov_openopps_43_digitalgov_gov_ns" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name = "openopps.digitalgov.gov."
-  type = "NS"
-  ttl = "300"
-  records = [
-    "ns-1886.awsdns-43.co.uk."
+    "openopps.usajobs.gov."
   ]
 }
 


### PR DESCRIPTION
`openopps.digitalgov.gov` has moved to OPM `openopps.usajobs.gov`. They are working on getting a proper 301 redirect set up on their end in the coming weeks, but in the meantime we are going to CNAME their old URL to the new URL so that users are not reaching a dead-end page.

---

PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.
