### PR TITLE
Reverting to old DNS for OPM / openopps.digitalgov.gov

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -86,16 +86,58 @@ resource "aws_route53_record" "demo_digitalgov_gov_a" {
 }
 
 
-# openopps.digitalgov.gov
-resource "aws_route53_record" "openopps_digitalgov_gov_a" {
+
+# OpenOpps ------------------------------------------
+
+resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_a" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "openopps.digitalgov.gov."
-  type = "CNAME"
-  ttl = "300"
-  records = [
-    "openopps.usajobs.gov."
-  ]
+  type = "A"
+  alias {
+    name = "d11og6pgwhrztr.cloudfront.net."
+    zone_id = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
 }
+
+resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_aaaa" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "openopps.digitalgov.gov."
+  type = "AAAA"
+  alias {
+    name = "d11og6pgwhrztr.cloudfront.net."
+    zone_id = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_mx" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "openopps.digitalgov.gov."
+  type = "MX"
+  ttl = 300
+  records = ["10	30288227.in1.mandrillapp.com", "20	30288227.in2.mandrillapp.com"]
+}
+
+resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_txt" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "openopps.digitalgov.gov."
+  type = "TXT"
+  ttl = 300
+  records = ["v=spf1 include:spf.mandrillapp.com ?all"]
+}
+
+resource "aws_route53_record" "digitalgov_gov_mandrill__domainkey_openopps_digitalgov_gov_txt" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "mandrill._domainkey.openopps.digitalgov.gov."
+  type = "TXT"
+  ttl = 300
+  records = ["v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrLHiExVd55zd/IQ/J/mRwSRMAocV/hMB3jXwaHH36d9NaVynQFYV8NaWi69c1veUtRzGt7yAioXqLj7Z4TeEUoOLgrKsn8YnckGs9i3B3tVFB+Ch/4mPhXWiNfNdynHWBcPcbJ8kjEQ2U8y78dHZj1YeRXXVvWob2OaKynO8/lQIDAQAB;"]
+}
+
+# END OpenOpps ------------------------------------------
+
+
 
 # usdigitalregistry.digitalgov.gov
 resource "aws_route53_record" "usdigitalregistry_digitalgov_gov_a" {


### PR DESCRIPTION
The team at OPM who are now the stewards of `OpenOpps.digitalgov.gov` would like to roll back all the DNS changes to their original configuration.

I asked @bmcorum, who is the lead engineer on this project at **OPM** to explain why they are moving back, and what the plans are for cleaning out the `openopps` records from the 18f/DNS repo so that we are only left with a simple 301 redirect.


---

_PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team._
