### PR TITLE
Added in the AAAA records for USWDS

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -43,7 +43,7 @@ resource "aws_route53_record" "demo_digital_gov_a" {
 }
 
 # USWDS -------------------------------
-# designsystem.digital.gov
+# designsystem.digital.gov — A
 resource "aws_route53_record" "designsystem_digital_gov_a" {
   zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
   name = "designsystem.digital.gov."
@@ -55,11 +55,35 @@ resource "aws_route53_record" "designsystem_digital_gov_a" {
   }
 }
 
-# components.designsystem.digital.gov
+# designsystem.digital.gov — AAAA
+resource "aws_route53_record" "designsystem_digital_gov_aaaa" {
+  zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
+  name = "designsystem.digital.gov."
+  type = "AAAA"
+  alias {
+    name = "dlu3fkwowya06.cloudfront.net."
+    zone_id = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}
+
+# components.designsystem.digital.gov — A
 resource "aws_route53_record" "components_designsystem_digital_gov_a" {
   zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
   name = "components.designsystem.digital.gov."
   type = "A"
+  alias {
+    name = "dxngby1kewpe.cloudfront.net."
+    zone_id = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}
+
+# components.designsystem.digital.gov — AAA
+resource "aws_route53_record" "components_designsystem_digital_gov_aaaa" {
+  zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
+  name = "components.designsystem.digital.gov."
+  type = "AAAA"
   alias {
     name = "dxngby1kewpe.cloudfront.net."
     zone_id = "Z2FDTNDATAQYW2"


### PR DESCRIPTION
These records were previously there in `usa.gov` so we are adding these in as well.

---

PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.
