### PR TITLE
HOLD till 6:45pm — Pointing the USWDS domains at the USA.gov redirect server

### DIFF
--- a/terraform/usa.gov.tf
+++ b/terraform/usa.gov.tf
@@ -27,45 +27,26 @@ resource "aws_route53_record" "usa_gov_analytics_usa_gov_aaaa" {
   }
 }
 
+# USWDS ------------------------------------------------
+# Pointing at the USA.gov redirect server
 resource "aws_route53_record" "usa_gov_components_standards_usa_gov_a" {
   zone_id = "${aws_route53_zone.usa_gov_zone.zone_id}"
   name = "components.standards.usa.gov."
   type = "A"
   alias {
-    name = "d1trwt77dwz8ml.cloudfront.net."
+    name = "54.85.132.205."
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
   }
 }
 
-resource "aws_route53_record" "usa_gov_components_standards_usa_gov_aaaa" {
-  zone_id = "${aws_route53_zone.usa_gov_zone.zone_id}"
-  name = "components.standards.usa.gov."
-  type = "AAAA"
-  alias {
-    name = "d1trwt77dwz8ml.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
-}
-
+# Pointing at the USA.gov redirect server
 resource "aws_route53_record" "usa_gov_standards_usa_gov_a" {
   zone_id = "${aws_route53_zone.usa_gov_zone.zone_id}"
   name = "standards.usa.gov."
   type = "A"
   alias {
-    name = "d98p4kkshmqgd.cloudfront.net."
-    zone_id = "Z2FDTNDATAQYW2"
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "usa_gov_standards_usa_gov_aaaa" {
-  zone_id = "${aws_route53_zone.usa_gov_zone.zone_id}"
-  name = "standards.usa.gov."
-  type = "AAAA"
-  alias {
-    name = "d98p4kkshmqgd.cloudfront.net."
+    name = "54.85.132.205."
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
   }


### PR DESCRIPTION
We are pointing the `srtandards.usa.gov` domains at a server operated by `usa.gov` team. They are handling the redirect for us. The new domain will be `designsystem.digital.gov`.

# ✋ Hold on merging till 6:45PM
 
---

_PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team._
