### PR TITLE
Go Go Cyber Go

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -310,6 +310,19 @@ resource "aws_route53_record" "support_digitalgov_gov_mx" {
   ]
 }
 
+
+# BOD 
+resource "aws_route53_record" "digitalgov_gov__dmarc_digitalgov_gov_txt" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "_dmarc.digitalgov.gov."
+  type = "TXT"
+  ttl = 300
+  records = [
+     "v=DMARC1; p=none; pct=10; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
+  ]
+}
+
+
 output "digitalgov_gov_ns" {
   value="${aws_route53_zone.digitalgov_gov_zone.name_servers}"
 }

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -314,7 +314,7 @@ resource "aws_route53_record" "support_digitalgov_gov_mx" {
 # BOD 
 resource "aws_route53_record" "digitalgov_gov_dmarc_digitalgov_gov_txt" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name = "_dmarc.digitalgov.gov."
+  name = "digitalgov.gov."
   type = "TXT"
   ttl = 300
   records = [

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -312,6 +312,16 @@ resource "aws_route53_record" "support_digitalgov_gov_mx" {
 
 
 # BOD 
+resource "aws_route53_record" "digitalgov_gov_dmarc_digitalgov_gov_txt" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "_dmarc.digitalgov.gov."
+  type = "TXT"
+  ttl = 300
+  records = [
+     "v=spf1 -all"
+  ]
+}
+
 resource "aws_route53_record" "digitalgov_gov__dmarc_digitalgov_gov_txt" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "_dmarc.digitalgov.gov."

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -318,7 +318,7 @@ resource "aws_route53_record" "digitalgov_gov__dmarc_digitalgov_gov_txt" {
   type = "TXT"
   ttl = 300
   records = [
-     "v=DMARC1; p=none; pct=10; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
+     "v=DMARC1; p=none; pct=100; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
   ]
 }
 


### PR DESCRIPTION
Implement SPF and DMARC for `digitalgov.gov` per BOD compliance

**This domain has been verified as non-Email sending domains and require SPF and DMARC records to come into compliance with BOD-18-01.** 

_PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team._
