### PR TITLE
Removing line breaks

### DIFF
--- a/terraform/vote.gov.tf
+++ b/terraform/vote.gov.tf
@@ -62,9 +62,7 @@ resource "aws_route53_record" "vote_gov_dmarc_vote_gov_txt" {
   name = "vote.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=spf1 -all"
-  ]
+  records = ["v=spf1 -all"]
 }
 
 resource "aws_route53_record" "vote_gov__dmarc_vote_gov_txt" {
@@ -72,9 +70,7 @@ resource "aws_route53_record" "vote_gov__dmarc_vote_gov_txt" {
   name = "_dmarc.vote.gov."
   type = "TXT"
   ttl = 300
-  records = [
-     "v=DMARC1; p=none; pct=100; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
-  ]
+  records = ["v=DMARC1; p=none; pct=100; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"]
 }
 
 output "vote_gov_ns" {


### PR DESCRIPTION
There were a few line breaks in this file that could be tripping up why the `DMARC records` were not showing up.


PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.
