### PR TITLE
Post migration update for CI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository holds the source code for configuring DNS for domains managed by
         1. Add a file for the domain (or subdomain, if the second-level domain isn't being added), to create the [public hosted zone](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingHostedZone.html).
             * [`18f.us`](terraform/18f.us.tf) is a good example to copy from.
             * You'll be using Terraform's [`aws_route53_zone`](https://www.terraform.io/docs/providers/aws/d/route53_zone.html).
-        1. After the pull request is merged, ask in [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure/) to get the nameservers for your domain from [Concourse](https://concourse-ci.fr.cloud.gov/teams/gsa-tts-infrastructure/pipelines/dns-prod/).
+        1. After the pull request is merged, to get the name servers for your domain check the output for your build in [CircleCI](https://circleci.com/gh/18F/dns).  If you need further assistance, check with [#admins-dns](https://gsa-tts.slack.com/messages/C4L58EQ5T).
         1. Change the nameservers for the domain to point to AWS.
             * For `.gov` domains, this will be done by the "domain manager" in [dotgov.gov](https://www.dotgov.gov/). The domain manager is likely someone in the respective agency's IT department.
 1. Add the relevant additional [record sets](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/rrsets-working-with.html). In Terraform, these are known as [`aws_route53_record`](https://www.terraform.io/docs/providers/aws/r/route53_record.html)s. Generally speaking, the required arguments are:
@@ -28,7 +28,7 @@ This repository holds the source code for configuring DNS for domains managed by
 
 It's worth noting that if you are pointing to a CloudFront distro, you should use Route 53's own `alias` and not a CNAME record. In fact, CNAMEing a top-level domain (or the top level of a delegated subdomain) is not allowed in DNS. See the various examples in the repo, such as [this one](https://github.com/18F/dns/blob/deploy/terraform/usa.gov.tf#L8-L17).
 
-On merge, changes are deployed to the cloud.gov AWS account automatically by an instance of Concourse hosted on [cloud.gov](https://cloud.gov). The configuration for the Concourse instance is in `pipeline.yml`.  Note:  Deployment migration to [CircleCI](https://circleci.com/gh/18F/dns) is in progress.
+On merge, changes are deployed to an AWS account hosting the Route53 records automatically by a [CircleCI](https://circleci.com/gh/18F/dns) job.
 
 **Please note: only production systems with an ATO should have their DNS configuration here. If you wish to create DNS records for pre-production systems, please use the domain `sandbox.gov` which is available in the [TTS Sandbox account](https://pages.18f.gov/before-you-ship/infrastructure/sandbox/).**
 


### PR DESCRIPTION
PRs affecting cloud.gov.tf or a Federalist site must receive approval from a member of the relevant team.
