### PR TITLE
generate a plan on every build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ jobs:
           name: Set up Terraform
           command: terraform init -backend-config=terraform/backend.tfvars -input=false terraform
       - run:
-          name: Validate Terraform
-          command: terraform validate terraform
+          name: Validate Terraform config and create the plan
+          command: terraform plan -out=tfplan -input=false terraform
 
       - persist_to_workspace:
           root: .
@@ -26,7 +26,7 @@ jobs:
 
       - run:
           name: Deploy the full environment
-          command: terraform apply -input=false -auto-approve terraform
+          command: terraform apply -input=false -auto-approve terraform/tfplan
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  validate_terraform:
+  plan:
     docker:
       - image: hashicorp/terraform:light
     steps:
@@ -17,7 +17,7 @@ jobs:
           paths:
             - ./*
 
-  deploy_env:
+  apply:
     docker:
       - image: hashicorp/terraform:light
     steps:
@@ -33,13 +33,13 @@ workflows:
 
   validate_and_deploy:
     jobs:
-      - validate_terraform
-      - deploy_env:
+      - plan
+      - apply:
           filters:
             branches:
               only: master
           requires:
-            - validate_terraform
+            - plan
 
 experimental:
   notify:

--- a/deploy
+++ b/deploy
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-aws s3 mb s3://${ENVIRONMENT_NAME}_dns_terraform_state
-terraform remote config -backend=s3 -backend-config="bucket=${ENVIRONMENT_NAME}_dns_terraform_state" -backend-config="key=network/terraform.tfstate" -backend-config="region=us-east-1"
-terraform apply -var env_name=${ENVIRONMENT_NAME} terraform


### PR DESCRIPTION
This has the benefit of not only validating the config, but also showing the contributor/reviewer exactly what would change before merging. The only downside I can think of is that green builds will take longer (minutes instead of seconds).

Included some other minor cleanup.

## Post-approve TODOs

* [ ] Update required build checks to match new names