### PR TITLE
Add developers.code.gov

### DIFF
--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -42,6 +42,18 @@ resource "aws_route53_record" "staging_code_gov_a" {
   }
 }
 
+resource "aws_route53_record" "staging_code_gov_a" {
+  zone_id = "${aws_route53_zone.code_toplevel.zone_id}"
+  name = "developers.code.gov."
+  type = "A"
+
+  alias {
+    name = "d3jsj3d37agtw.cloudfront.net."
+    zone_id = "${local.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "code_gov_api_cname" {
   zone_id = "${aws_route53_zone.code_toplevel.zone_id}"
   name = "api.code.gov."

--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -42,7 +42,7 @@ resource "aws_route53_record" "staging_code_gov_a" {
   }
 }
 
-resource "aws_route53_record" "developers_code_gov_a" {
+resource "aws_route53_record" "code_gov_developers_code_gov_a" {
   zone_id = "${aws_route53_zone.code_toplevel.zone_id}"
   name = "developers.code.gov."
   type = "A"

--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -42,7 +42,7 @@ resource "aws_route53_record" "staging_code_gov_a" {
   }
 }
 
-resource "aws_route53_record" "staging_code_gov_a" {
+resource "aws_route53_record" "developers_code_gov_a" {
   zone_id = "${aws_route53_zone.code_toplevel.zone_id}"
   name = "developers.code.gov."
   type = "A"


### PR DESCRIPTION
- Added developers.code.gov sub-domain configuration

PRs affecting a Federalist site must receive approval from a member of the relevant team.
