### PR TITLE
Add email-verification-related records for support.digitalgov.gov

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -64,6 +64,39 @@ resource "aws_route53_record" "dap_validation_digitalgov_gov_a" {
 }
 # ===== End temporary record for validation =====
 
+# required for AWS SES to DKIM-sign emails sent "From" support.digitalgov.gov
+resource "aws_route53_record" "support_digitalgov_gov_ses_dkim_a" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "4ixtpnvpubjuxqvnex727otq55y2ew7w._domainkey.support.digitalgov.gov."
+  type = "CNAME"
+  ttl = "300"
+  records = [
+    "4ixtpnvpubjuxqvnex727otq55y2ew7w.dkim.amazonses.com"
+  ]
+}
+
+# required for AWS SES to DKIM-sign emails sent "From" support.digitalgov.gov
+resource "aws_route53_record" "support_digitalgov_gov_ses_dkim_b" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "tmoxp5vgftwsmhkukt2z6ayvfj5bw7zo._domainkey.support.digitalgov.gov."
+  type = "CNAME"
+  ttl = "300"
+  records = [
+    "tmoxp5vgftwsmhkukt2z6ayvfj5bw7zo.dkim.amazonses.com"
+  ]
+}
+
+# required for AWS SES to DKIM-sign emails sent "From" support.digitalgov.gov
+resource "aws_route53_record" "support_digitalgov_gov_ses_dkim_c" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "5uiojtkg7z5grkldq7ajm3zamtzh3h2s._domainkey.support.digitalgov."
+  type = "CNAME"
+  ttl = "300"
+  records = [
+    "5uiojtkg7z5grkldq7ajm3zamtzh3h2s.dkim.amazonses.com"
+  ]
+}
+
 
 # www.digitalgov.gov
 resource "aws_route53_record" "digitalgov_gov_www" {
@@ -277,10 +310,21 @@ resource "aws_route53_record" "digitalgov_gov_support_digitalgov_gov_txt" {
   type = "TXT"
   ttl = "3600"
   records = [
-    "v=spf1 include:spf.mandrillapp.com include:mail.zendesk.com include:emailsrvr.com include:servers.mcsv.net ~all"
+    "v=spf1 include:spf.mandrillapp.com include:mail.zendesk.com include:emailsrvr.com include:servers.mcsv.net include:amazonses.com ~all"
   ]
 }
 
+
+# required by AWS SES to verify control of the support.digitalgov.gov domain
+resource "aws_route53_record" "support_digitalgov_gov_ses_verification" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "_amazonses.support.digitalgov.gov."
+  type = "TXT"
+  ttl = "3600"
+  records = [
+    "T5etn/YylzSUQQWw6HspyK4+2+B9XzE7Kajpz9ogfJI="
+  ]
+}
 
 
 

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -246,6 +246,7 @@ resource "aws_route53_record" "find_digitalgov_gov_a" {
   ]
 }
 
+# this record can be removed after 2018-03-31 once the search-gov app is no longer sending emails via Mandrill
 # k1._domainkey.support.digitalgov.gov — CNAME
 resource "aws_route53_record" "k1_domainkey_support_digitalgov_gov_a" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
@@ -294,6 +295,7 @@ resource "aws_route53_record" "digitalgov_gov_m1_domainkey_digitalgov_gov_txt" {
   ]
 }
 
+# this record can be removed after 2018-03-31 once the search-gov app is no longer sending emails via Mandrill
 # mandrill._domainkey.support.digitalgov.gov - TXT
 resource "aws_route53_record" "digitalgov_gov_mandrill_domainkey_digitalgov_gov_txt" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
@@ -303,6 +305,7 @@ resource "aws_route53_record" "digitalgov_gov_mandrill_domainkey_digitalgov_gov_
   records = ["${local.mandrill_dkim}"]
 }
 
+# the Mandrill-related values in this record can be removed after 2018-03-31 once the search-gov app is no longer sending emails via Mandrill
 # support.digitalgov.gov - TXT
 resource "aws_route53_record" "digitalgov_gov_support_digitalgov_gov_txt" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.

The Search.gov team is transitioning from sending emails via Mandrill to sending emails via AWS SES.

This PR adds four new `support.digitalgov.gov` DNS records that are needed to set up AWS SES to send emails on behalf of the [search-gov app](https://github.com/GSA/search-gov). It also modifies an existing SPF record. We intend to remove Mandrill-related content from DNS records after the transition is complete.

This summarizes the four records I'm attempting to create.

| Purpose                 | DNS Record Name                                                      | DNS Record Type | DNS Record Value                                      |
| ----------------------- | -------------------------------------------------------------------- | --------------- | ----------------------------------------------------- |
| SES Domain Verification | `_amazonses.support.digitalgov.gov.`                                  | `TXT`           | `T5etn/YylzSUQQWw6HspyK4+2+B9XzE7Kajpz9ogfJI=`        |
| DKIM                    | `4ixtpnvpubjuxqvnex727otq55y2ew7w._domainkey.support.digitalgov.gov.` | `CNAME`         | `4ixtpnvpubjuxqvnex727otq55y2ew7w.dkim.amazonses.com` |
| DKIM                    | `tmoxp5vgftwsmhkukt2z6ayvfj5bw7zo._domainkey.support.digitalgov.gov.` | `CNAME`         | `tmoxp5vgftwsmhkukt2z6ayvfj5bw7zo.dkim.amazonses.com` |
| DKIM                    | `5uiojtkg7z5grkldq7ajm3zamtzh3h2s._domainkey.support.digitalgov.gov.` | `CNAME`         | `5uiojtkg7z5grkldq7ajm3zamtzh3h2s.dkim.amazonses.com` |

I've double checked my work, and I think the change is correct. But this is my first PR here, so a careful review would be appreciated. Thanks!