### PR TITLE
add note about where to make changes, git-wise

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # TTS DNS configuration
 
 [![CircleCI](https://circleci.com/gh/18F/dns.svg?branch=master&style-svg)](https://circleci.com/gh/18F/dns)
@@ -8,6 +7,8 @@ This repository holds the source code for configuring DNS for domains managed by
 [![dns-pipeline](https://user-images.githubusercontent.com/20934414/34623560-7dd34d3c-f217-11e7-95fd-1cc8236d4b5b.png)](https://github.com/18F/Infrastructure/wiki/DNS-architecture)
 
 ## Making changes
+
+Assuming you're 18F staff, it's recommended that you make the change in a branch on this repository itself, rather than on a fork. CI builds on forks will fail, because the credentials aren't shared with forks.
 
 1. Is the domain pointing to the right nameservers? In other words, is there a file for the domain under [`terraform/`](terraform) already?
     * **Yes:** Continue to next step.


### PR DESCRIPTION
Build fails from forks due to this setting in CircleCI:

<img width="1362" alt="screen shot 2018-03-26 at 1 59 37 pm" src="https://user-images.githubusercontent.com/86842/37923756-f98db028-30fd-11e8-8328-a28e9532fc1d.png">

Noting this for later, in case someone wants to put in the effort to make it fail more gracefully:

https://discuss.circleci.com/t/create-separate-steps-jobs-for-pr-forks-versus-branches/13419

Also, gave the 18F GitHub team write access to the repo, which should be fine because the `master` branch is protected.