### PR TITLE
[HOLD] digitalgov.gov to digital.gov

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -6,37 +6,41 @@ resource "aws_route53_zone" "digital_toplevel" {
   }
 }
 
+# digital.gov
 resource "aws_route53_record" "digital_gov_apex" {
   zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
   name = "digital.gov."
   type = "A"
 
   alias {
-    name = "d2q1i25any8vwy.cloudfront.net."
+    name = "djce1rrjucuix.cloudfront.net."
     zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
 
+# www.digital.gov
+# redirects to digital.gov via Federalist redirect
 resource "aws_route53_record" "digital_gov_www" {
   zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
   name = "www.digital.gov."
   type = "A"
 
   alias {
-    name = "d2q1i25any8vwy.cloudfront.net."
+    name = "d1wh5biaq5z7yu.cloudfront.net."
     zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
 
+# demo.digital.gov
 resource "aws_route53_record" "demo_digital_gov_a" {
   zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
   name = "demo.digital.gov."
   type = "A"
 
   alias {
-    name = "d1f2igtqmwwbgm.cloudfront.net."
+    name = "d3oyi0vhjafspr.cloudfront.net."
     zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -227,7 +227,7 @@ resource "aws_route53_record" "summit_digitalgov_gov_a" {
   type = "CNAME"
   ttl = "300"
   records = [
-    "www.usa.gov.edgekey.net."
+    "d1wh5biaq5z7yu.cloudfront.net."
   ]
 }
 

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -5,17 +5,45 @@ resource "aws_route53_zone" "digitalgov_gov_zone" {
   }
 }
 
-# digitalgov.gov - - - this redirects to www.digitalgov.gov
+# digitalgov.gov
+# redirects to digital.gov via Federalist Redirect
+# See: https://github.com/18F/pages-redirects
 resource "aws_route53_record" "digitalgov_gov_apex" {
  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
  name = "digitalgov.gov."
  type = "A"
 
  alias {
-   name = "d2a6ofmg0xhw1g.cloudfront.net."
+   name = "d1wh5biaq5z7yu.cloudfront.net."
    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
    evaluate_target_health = false
  }
+}
+
+# www.digitalgov.gov
+# redirects to digital.gov via Federalist Redirect
+# See: https://github.com/18F/pages-redirects
+resource "aws_route53_record" "digitalgov_gov_www" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "www.digitalgov.gov."
+  type = "CNAME"
+  ttl = "300"
+  records = [
+    "d1wh5biaq5z7yu.cloudfront.net."
+  ]
+}
+
+# demo.digitalgov.gov
+# redirects to demo.digital.gov via Federalist Redirect
+# See: https://github.com/18F/pages-redirects
+resource "aws_route53_record" "demo_digitalgov_gov_a" {
+  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
+  name = "demo.digitalgov.gov."
+  type = "CNAME"
+  ttl = "300"
+  records = [
+    "d1wh5biaq5z7yu.cloudfront.net."
+  ]
 }
 
 # o166.email.digitalgov.gov — A
@@ -98,27 +126,6 @@ resource "aws_route53_record" "support_digitalgov_gov_ses_dkim_c" {
 }
 
 
-# www.digitalgov.gov
-resource "aws_route53_record" "digitalgov_gov_www" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name = "www.digitalgov.gov."
-  type = "CNAME"
-  ttl = "300"
-  records = [
-    "djce1rrjucuix.cloudfront.net."
-  ]
-}
-
-# demo.digitalgov.gov
-resource "aws_route53_record" "demo_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name = "demo.digitalgov.gov."
-  type = "CNAME"
-  ttl = "300"
-  records = [
-    "d3oyi0vhjafspr.cloudfront.net."
-  ]
-}
 
 
 


### PR DESCRIPTION
# 🚨HOLD

## What we're changing

We are redirecting `digitalgov.gov` and `www.digitalgov.gov` to ➡️ `digital.gov` with a 301 redirect.

**See: https://github.com/18F/pages-redirects/pull/100**

We are hoping that all paths also resolve under the new `digital.gov` URL. For example, `digitalgov.gov/events/` should redirect to `digital.gov/events/`

## In this change
The following domains will be redirected to the Federalist Redirect Server — `d1wh5biaq5z7yu.cloudfront.net`
- `digitalgov.gov` 
- `www.digitalgov.gov` 
- `demo.digitalgov.gov`
- `www.digital.gov`

In addition, we are making sure the NEW domain is pointing to the correct CloudFront URLs
- `digital.gov` is being pointed at the cloudfront url for the main site — `djce1rrjucuix.cloudfront.net` — this was formerly `www.digitalgov.gov`, _[see the current terraform file / line 101](https://github.com/18F/dns/blob/master/terraform/digitalgov.gov.tf#L101)_
- `demo.digital.gov` is being pointed at the cloudfront url for the demo site — `d3oyi0vhjafspr.cloudfront.net` — _[see the current terraform file / line 112](https://github.com/18F/dns/blob/master/terraform/digitalgov.gov.tf#L112)_

# 🚨HOLD
---

_PRs affecting a Federalist site must receive approval from a member of the relevant team._
