### PR TITLE
Remove Mandrill-related values from support.digitalgov.gov records and temporarily lower TTL for MX record

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -246,18 +246,6 @@ resource "aws_route53_record" "find_digitalgov_gov_a" {
   ]
 }
 
-# this record can be removed after 2018-03-31 once the search-gov app is no longer sending emails via Mandrill
-# k1._domainkey.support.digitalgov.gov — CNAME
-resource "aws_route53_record" "k1_domainkey_support_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name = "k1._domainkey.support.digitalgov.gov."
-  type = "CNAME"
-  ttl = "300"
-  records = [
-    "dkim.mcsv.net."
-  ]
-}
-
 
 # ==========
 # TXT Records
@@ -295,17 +283,7 @@ resource "aws_route53_record" "digitalgov_gov_m1_domainkey_digitalgov_gov_txt" {
   ]
 }
 
-# this record can be removed after 2018-03-31 once the search-gov app is no longer sending emails via Mandrill
-# mandrill._domainkey.support.digitalgov.gov - TXT
-resource "aws_route53_record" "digitalgov_gov_mandrill_domainkey_digitalgov_gov_txt" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name = "mandrill._domainkey.support.digitalgov.gov."
-  type = "TXT"
-  ttl = "3600"
-  records = ["${local.mandrill_dkim}"]
-}
-
-# the Mandrill-related values in this record can be removed after 2018-03-31 once the search-gov app is no longer sending emails via Mandrill
+# the emailsrvr.com part in this record can be removed once we've safely transitioned incoming email handling from Rackspace to AWS SES
 # support.digitalgov.gov - TXT
 resource "aws_route53_record" "digitalgov_gov_support_digitalgov_gov_txt" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
@@ -313,7 +291,7 @@ resource "aws_route53_record" "digitalgov_gov_support_digitalgov_gov_txt" {
   type = "TXT"
   ttl = "3600"
   records = [
-    "v=spf1 include:spf.mandrillapp.com include:mail.zendesk.com include:emailsrvr.com include:servers.mcsv.net include:amazonses.com ~all"
+    "v=spf1 include:mail.zendesk.com include:emailsrvr.com include:amazonses.com ~all"
   ]
 }
 
@@ -351,7 +329,7 @@ resource "aws_route53_record" "support_digitalgov_gov_mx" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "support.digitalgov.gov."
   type = "MX"
-  ttl = "600"
+  ttl = "60"
   records = [
     "10 mx1.emailsrvr.com."
   ]


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.

This is the first in a series of three DNS changes the search.gov team is requesting in order to transition incoming email processing for `support.digitalgov.gov` from Rackspace to AWS SES:

1. reduce the TTL for the `support.digitalgov.gov` MX record to 1 minute in preparation for updating it (also cleaning up some old Mandrill-related values in `support.digitalgov.gov` DNS records)
2. updating the `search.digitalgov.gov` MX record to point to SES's incoming SMTP endpoint while being prepared to roll back the change if we encounter trouble
3. increase the TTL for the `support.digitalgov.gov` MX record back to 10 minutes (also cleaning up any Rackspace-related values in `support.digitalgov.gov` DNS records)

We plan on issuing a PR for (2) tomorrow morning.
