### PR TITLE
make builds pass on pull requests from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,15 @@ jobs:
           name: Set up Terraform
           command: terraform init -backend-config=terraform/backend.tfvars -input=false terraform
       - run:
-          name: Validate Terraform config and create the plan
-          command: terraform plan -input=false terraform
+          name: Validate Terraform config
+          # https://discuss.circleci.com/t/create-separate-steps-jobs-for-pr-forks-versus-branches/13419/2
+          command: |
+            if [[ ((`echo $CIRCLE_BRANCH | grep -c "pull"` > 0))]]; then
+              echo "This is from a fork."
+              terraform validate terraform
+            else
+              terraform plan -input=false terraform
+            fi
 
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           name: Validate Terraform config
           # https://discuss.circleci.com/t/create-separate-steps-jobs-for-pr-forks-versus-branches/13419/2
           command: |
-            if [[ ((`echo $CIRCLE_BRANCH | grep -c "pull"` > 0))]]; then
+            if [[ $(echo "$CIRCLE_BRANCH" | grep -c "pull") -gt 0 ]]; then
               echo "This is from a fork."
               terraform validate terraform
             else

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository holds the source code for configuring DNS for domains managed by
 
 ## Making changes
 
-Assuming you're 18F staff, it's recommended that you make the change in a branch on this repository itself, rather than on a fork. CI builds on forks will fail, because the credentials aren't shared with forks.
+Assuming you're TTS staff, it's recommended that you **make the change in a branch on this repository itself, rather than on a fork**, because the credentials aren't shared with forks.
 
 1. Is the domain pointing to the right nameservers? In other words, is there a file for the domain under [`terraform/`](terraform) already?
     * **Yes:** Continue to next step.


### PR DESCRIPTION
Follow-up to #226.

The credentials aren't shared with builds form forks for security reasons, so the `terraform plan` will fail. This pull request changes the build to do a `validate` in those cases instead.