### PR TITLE
Move incoming email processing for support.digitalgov.gov to SES

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -331,7 +331,7 @@ resource "aws_route53_record" "support_digitalgov_gov_mx" {
   type = "MX"
   ttl = "60"
   records = [
-    "10 mx1.emailsrvr.com."
+    "10 inbound-smtp.us-east-1.amazonaws.com."
   ]
 }
 


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.

This is the second in a series of three DNS changes the search.gov team is requesting in order to transition incoming email processing for `support.digitalgov.gov` from Rackspace to AWS SES:

1. ~~reduce the TTL for the `support.digitalgov.gov` MX record to 1 minute in preparation for updating it (also cleaning up some old Mandrill-related values in `support.digitalgov.gov` DNS records)~~
2. updating the `search.digitalgov.gov` MX record to point to SES's incoming SMTP endpoint while being prepared to roll back the change if we encounter trouble
3. increase the TTL for the `support.digitalgov.gov` MX record back to 10 minutes (also cleaning up any Rackspace-related values in `support.digitalgov.gov` DNS records)

We plan on issuing a PR for (3) later today once we're convinced everything is working in SES properly.
