### PR TITLE
Removing openopps mandrill records

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -135,31 +135,6 @@ resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_a" {
   }
 }
 
-resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_mx" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name = "openopps.digitalgov.gov."
-  type = "MX"
-  ttl = 300
-  records = ["${local.mandrill_mx}"]
-}
-
-resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_txt" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name = "openopps.digitalgov.gov."
-  type = "TXT"
-  ttl = 300
-  records = ["${local.mandrill_spf}"]
-}
-
-resource "aws_route53_record" "digitalgov_gov_mandrill__domainkey_openopps_digitalgov_gov_txt" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name = "mandrill._domainkey.openopps.digitalgov.gov."
-  type = "TXT"
-  ttl = 300
-  records = ["${local.mandrill_dkim}"]
-}
-
-
 
 
 # usdigitalregistry -------------------------------------


### PR DESCRIPTION
### Removing Mandrill MX records for openopps.digitalgov.gov

We’re still getting pinged on BOD 18-01 because those records exist and we are no longer using Mandrill.

I confirmed with the openopps team that they are no longer using these.

---

PRs affecting a Federalist site must receive approval from a member of the relevant team.
