### PR TITLE
pointing demo at federalist redirect app

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -116,7 +116,7 @@ resource "aws_route53_record" "demo_digitalgov_gov_a" {
   type = "CNAME"
   ttl = "300"
   records = [
-    "d3oyi0vhjafspr.cloudfront.net."
+    "djce1rrjucuix.cloudfront.net."
   ]
 }
 

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -116,7 +116,7 @@ resource "aws_route53_record" "demo_digitalgov_gov_a" {
   type = "CNAME"
   ttl = "300"
   records = [
-    "djce1rrjucuix.cloudfront.net."
+    "https://d1wh5biaq5z7yu.cloudfront.net/."
   ]
 }
 

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -116,7 +116,7 @@ resource "aws_route53_record" "demo_digitalgov_gov_a" {
   type = "CNAME"
   ttl = "300"
   records = [
-    "https://d1wh5biaq5z7yu.cloudfront.net/."
+    "d1wh5biaq5z7yu.cloudfront.net."
   ]
 }
 


### PR DESCRIPTION

We are pointing demo.digitalgov.gov at federalist redirect app
`djce1rrjucuix.cloudfront.net`

---

PRs affecting a Federalist site must receive approval from a member of the relevant team.
