### PR TITLE
Revert "pointing demo at federalist redirect app"

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -116,7 +116,7 @@ resource "aws_route53_record" "demo_digitalgov_gov_a" {
   type = "CNAME"
   ttl = "300"
   records = [
-    "d1wh5biaq5z7yu.cloudfront.net."
+    "d3oyi0vhjafspr.cloudfront.net."
   ]
 }
 


### PR DESCRIPTION
This didn't work, so we are reverting 18F/dns#240

