### PR TITLE
use Circle branch filters to segment fork vs. non-fork builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,16 @@ jobs:
       - checkout
       - run:
           name: Set up Terraform
-          command: terraform init -backend-config=terraform/backend.tfvars -input=false terraform
+          # https://discuss.circleci.com/t/create-separate-steps-jobs-for-pr-forks-versus-branches/13419/2
+          command: |
+            if [[ $(echo "$CIRCLE_BRANCH" | grep -c "pull") -gt 0 ]]; then
+              echo "This is from a fork."
+              terraform init -backend=false -input=false terraform
+            else
+              terraform init -backend-config=terraform/backend.tfvars -input=false terraform
+            fi
       - run:
           name: Validate Terraform config
-          # https://discuss.circleci.com/t/create-separate-steps-jobs-for-pr-forks-versus-branches/13419/2
           command: |
             if [[ $(echo "$CIRCLE_BRANCH" | grep -c "pull") -gt 0 ]]; then
               echo "This is from a fork."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,17 @@
 version: 2
 jobs:
+  validate:
+    docker:
+      - image: hashicorp/terraform:light
+    steps:
+      - checkout
+      - run:
+          name: Set up Terraform
+          command: terraform init -backend=false -input=false terraform
+      - run:
+          name: Validate Terraform config
+          command: terraform validate terraform
+
   plan:
     docker:
       - image: hashicorp/terraform:light
@@ -7,24 +19,10 @@ jobs:
       - checkout
       - run:
           name: Set up Terraform
-          # https://discuss.circleci.com/t/create-separate-steps-jobs-for-pr-forks-versus-branches/13419/2
-          command: |
-            if [[ $(echo "$CIRCLE_BRANCH" | grep -c "pull") -gt 0 ]]; then
-              echo "This is from a fork."
-              terraform init -backend=false -input=false terraform
-            else
-              terraform init -backend-config=terraform/backend.tfvars -input=false terraform
-            fi
+          command: terraform init -backend-config=terraform/backend.tfvars -input=false terraform
       - run:
-          name: Validate Terraform config
-          command: |
-            if [[ $(echo "$CIRCLE_BRANCH" | grep -c "pull") -gt 0 ]]; then
-              echo "This is from a fork."
-              terraform validate terraform
-            else
-              terraform plan -input=false terraform
-            fi
-
+          name: Compute changes
+          command: terraform plan -input=false terraform
       - persist_to_workspace:
           root: .
           paths:
@@ -46,7 +44,18 @@ workflows:
 
   validate_and_deploy:
     jobs:
-      - plan
+      # https://discuss.circleci.com/t/create-separate-steps-jobs-for-pr-forks-versus-branches/13419
+      - validate:
+          filters:
+            branches:
+              # only from forks
+              only: /^pull\/.*$/
+      - plan:
+          filters:
+            branches:
+              # only run on branches from canonical repository
+              # https://stackoverflow.com/a/5334825/358804
+              only: /^(?!pull\/).*$/
       - apply:
           filters:
             branches:


### PR DESCRIPTION
This is an experiment to see if the Circle configuration can support this type of configuration natively, rather than using shell conditionals. Neither is super readable. Thoughts?