### PR TITLE
Restore longer TTL value for MX record and clean up SPF TXT record for support.digitalgov.gov

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -258,7 +258,6 @@ resource "aws_route53_record" "digitalgov_gov_m1_domainkey_digitalgov_gov_txt" {
   ]
 }
 
-# the emailsrvr.com part in this record can be removed once we've safely transitioned incoming email handling from Rackspace to AWS SES
 # support.digitalgov.gov - TXT
 resource "aws_route53_record" "digitalgov_gov_support_digitalgov_gov_txt" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
@@ -266,7 +265,7 @@ resource "aws_route53_record" "digitalgov_gov_support_digitalgov_gov_txt" {
   type = "TXT"
   ttl = "3600"
   records = [
-    "v=spf1 include:mail.zendesk.com include:emailsrvr.com include:amazonses.com ~all"
+    "v=spf1 include:mail.zendesk.com include:amazonses.com ~all"
   ]
 }
 
@@ -304,7 +303,7 @@ resource "aws_route53_record" "support_digitalgov_gov_mx" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
   name = "support.digitalgov.gov."
   type = "MX"
-  ttl = "60"
+  ttl = "600"
   records = [
     "10 inbound-smtp.us-east-1.amazonaws.com."
   ]


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.

This is the third and final PR in a series of three DNS changes the search.gov team is requesting in order to transition incoming email processing for support.digitalgov.gov from Rackspace to AWS SES:

* ~~reduce the TTL for the support.digitalgov.gov MX record to 1 minute in preparation for updating it (also cleaning up some old Mandrill-related values in support.digitalgov.gov DNS records)~~ (#234)
* ~~update the search.digitalgov.gov MX record to point to SES's incoming SMTP endpoint while being prepared to roll back the change if we encounter trouble~~ (#236)
* increase the TTL for the support.digitalgov.gov MX record back to 10 minutes (also clean up any Rackspace-related values in support.digitalgov.gov DNS records)

In #236 I was told to target any further PRs at the `local-for-circle` branch in this repo, but since I hear there's been some more work done to get PRs from forks working again, I'm taking my chances and targeting `master` for now. I'll change the target if I encounter any CI trouble.