### PR TITLE
adding in dmarc_reject

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -118,7 +118,7 @@ resource "aws_route53_record" "digital_gov__dmarc_digital_gov_txt" {
   name = "_dmarc.digital.gov."
   type = "TXT"
   ttl = 300
-  records = ["${local.dmarc_100}"]
+  records = ["${local.dmarc_reject}"]
 }
 
 output "digital_ns" {

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -325,7 +325,7 @@ resource "aws_route53_record" "digitalgov_gov__dmarc_digitalgov_gov_txt" {
   name = "_dmarc.digitalgov.gov."
   type = "TXT"
   ttl = 300
-  records = ["${local.dmarc_100}"]
+  records = ["${local.dmarc_reject}"]
 }
 
 

--- a/terraform/innovation.gov.tf
+++ b/terraform/innovation.gov.tf
@@ -56,7 +56,7 @@ resource "aws_route53_record" "innovation_gov__dmarc_innovation_gov_txt" {
   name = "_dmarc.innovation.gov."
   type = "TXT"
   ttl = 300
-  records = ["${local.dmarc_100}"]
+  records = ["${local.dmarc_reject}"]
 }
 
 output "innovation_ns" {


### PR DESCRIPTION

## adding dmarc_reject for the following domains
- digital.gov
- digitalgov.gov
- innovation.gov

---
_PRs affecting a Federalist site must receive approval from a member of the relevant team._
