### PR TITLE
Update pif.gov.tf to remove beta.pif.gov

### DIFF
--- a/terraform/pif.gov.tf
+++ b/terraform/pif.gov.tf
@@ -98,14 +98,6 @@ resource "aws_route53_record" "proposal_cname" {
   records = ["proposal.pif.gov.00du0000000leuxmac.live.siteforce.com"]
 }
 
-resource "aws_route53_record" "beta" {
-  zone_id = "${aws_route53_zone.pif_toplevel.zone_id}"
-  name = "beta.pif.gov."
-  type = "CNAME"
-  ttl = 60
-  records = ["presidential-innovation-fellows.github.io"]
-}
-
 resource "aws_route53_record" "recalls_cname" {
   zone_id = "${aws_route53_zone.pif_toplevel.zone_id}"
   name = "recalls.pif.gov."


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.
