### PR TITLE
Added v2 for the USWDS

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -93,6 +93,18 @@ resource "aws_route53_record" "components_designsystem_digital_gov_aaaa" {
   }
 }
 
+# v2.designsystem.digital.gov — A -------------------------------
+resource "aws_route53_record" "v2_designsystem_digital_gov_a" {
+  zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
+  name = "v2.designsystem.digital.gov."
+  type = "A"
+  alias {
+    name = "d3pcqg083enklv.cloudfront.net."
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
 # emerging.digital.gov — A -------------------------------
 resource "aws_route53_record" "emerging_digital_gov_a" {
   zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"


### PR DESCRIPTION
The USWDS is preparing to launch version 2.0 of their design system. This is a URL to build on and start to promote v2 within the community before launch.

---
PRs affecting a Federalist site must receive approval from a member of the relevant team.
