### PR TITLE
remove blogging guide

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -270,14 +270,6 @@ resource "aws_route53_record" "18f_gov_automated-testing-playbook_18f_gov_a" {
   }
 }
 
-resource "aws_route53_record" "18f_gov_blogging-guide_18f_gov_cname" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "blogging-guide.18f.gov."
-  type = "CNAME"
-  ttl = 300
-  records = ["pages-redirects.app.cloud.gov"]
-}
-
 resource "aws_route53_record" "18f_gov_before-you-ship_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "before-you-ship.18f.gov."


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.
