### PR TITLE
Update api.open.fec.gov and api-stage.open.fec.gov CNAMEs for api.data.gov

### DIFF
--- a/terraform/open.fec.gov.tf
+++ b/terraform/open.fec.gov.tf
@@ -23,7 +23,7 @@ resource "aws_route53_record" "open_fec_gov_api-stage_open_fec_gov_cname" {
   name    = "api-stage.open.fec.gov."
   type    = "CNAME"
   ttl     = 300
-  records = ["api-open-fec-2086140464.us-east-1.elb.amazonaws.com."]
+  records = ["api-open-fec-gov.domains.api.data.gov."]
 }
 
 resource "aws_route53_record" "open_fec_gov_api_open_fec_gov_cname" {
@@ -31,7 +31,7 @@ resource "aws_route53_record" "open_fec_gov_api_open_fec_gov_cname" {
   name    = "api.open.fec.gov."
   type    = "CNAME"
   ttl     = 300
-  records = ["api-open-fec-2086140464.us-east-1.elb.amazonaws.com."]
+  records = ["api-open-fec-gov.domains.api.data.gov."]
 }
 
 resource "aws_route53_record" "open_fec_gov_a33103137e39f452e19e75a2bd2ccb02_api_open_fec_gov_cname" {


### PR DESCRIPTION
See: https://github.com/fecgov/openFEC/issues/3293

api.data.gov is completing some underlying service changes, so we've asked some agencies to update CNAMEs they had pointing to our infrastructure. Since these domains appears to be managed here for FEC (yay!), I thought I'd go ahead and submit a pull request for this change, but let us know if there's actually a different process for this.

The current CNAME of api-open-fec-2086140464.us-east-1.elb.amazonaws.com is an ELB that the api.data.gov service owns, and we'd instead like these to point to api-open-fec-gov.domains.api.data.gov (which currently resolve to the same IPs, but this switch will allow us to complete some underlying api.data.gov upgrades without further CNAME switches).

Let me know if you have any questions or we need to do anything else. Thanks!