### PR TITLE
BOD 18-01 compliance for presidentialinnovationfellows.gov

### DIFF
--- a/terraform/presidentialinnovationfellows.gov.tf
+++ b/terraform/presidentialinnovationfellows.gov.tf
@@ -46,12 +46,20 @@ resource "aws_route53_record" "presidentialinnovationfellows_apex_txt" {
   records = ["google-site-verification=RBhAMKMQvrHWfxNfosQ9oUrrcwAme78JlrhD3cTQCvY"]
 }
 
+resource "aws_route53_record" "presidentialinnovationfellows_txt" {
+  zone_id = "${aws_route53_zone.presidentialinnovationfellows_toplevel.zone_id}"
+  name = "presidentialinnovationfellows.gov."
+  type = "TXT"
+  ttl = 300
+  records = ["${local.spf_no_mail}"]
+}
+
 resource "aws_route53_record" "presidentialinnovationfellows__dmarc_presidentialinnovationfellows_txt" {
   zone_id = "${aws_route53_zone.presidentialinnovationfellows_toplevel.zone_id}"
   name = "_dmarc.presidentialinnovationfellows.gov."
   type = "TXT"
   ttl = 300
-  records = ["${local.dmarc_10}"]
+  records = ["${local.dmarc_reject}"]
 }
 
 resource "aws_route53_record" "presidentialinnovationfellows_amazonses" {


### PR DESCRIPTION
Setting `spf_no_mail` and `dmarc_reject` for presidentialinnovationfellows.gov

cc: @joshuadifrances & @wslack -- this site is hosted by Federalist.