### PR TITLE
Add federalistapp.18f.gov and federalistapp-staging.18f.gov domains

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -490,9 +490,25 @@ resource "aws_route53_record" "18f_gov_federalist_18f_gov_cname" {
   records = ["d189ghshxys967.cloudfront.net"]
 }
 
+resource "aws_route53_record" "18f_gov_federalistapp_18f_gov_cname" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "federalistapp.18f.gov."
+  type = "CNAME"
+  ttl = 60
+  records = ["d189ghshxys967.cloudfront.net"]
+}
+
 resource "aws_route53_record" "18f_gov_federalist-staging_18f_gov_cname" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "federalist-staging.18f.gov."
+  type = "CNAME"
+  ttl = 60
+  records = ["d3e7le7trh4ed5.cloudfront.net"]
+}
+
+resource "aws_route53_record" "18f_gov_federalistapp-staging_18f_gov_cname" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "federalistapp-staging.18f.gov."
   type = "CNAME"
   ttl = 60
   records = ["d3e7le7trh4ed5.cloudfront.net"]


### PR DESCRIPTION
In preparation to host the primary 18F website in Federalist (we are migrating the web content from 18F/federalist to 18f/federalist-doc), we need to move the main Federalist app into its own domain. Before doing a hard switch, we want to create duplicates of the existing sites with new domains for testing. This is that pull request.