### PR TITLE
remove federalist-staging.18f.gov

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -506,14 +506,6 @@ resource "aws_route53_record" "18f_gov_federalistapp_18f_gov_cname" {
   records = ["d189ghshxys967.cloudfront.net"]
 }
 
-resource "aws_route53_record" "18f_gov_federalist-staging_18f_gov_cname" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "federalist-staging.18f.gov."
-  type = "CNAME"
-  ttl = 60
-  records = ["dzenn40bgakrn.cloudfront.net"]
-}
-
 resource "aws_route53_record" "18f_gov_federalistapp-staging_18f_gov_cname" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "federalistapp-staging.18f.gov."


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.
