### PR TITLE
remove fedealistapp.18f.gov

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -498,14 +498,6 @@ resource "aws_route53_record" "18f_gov_federalist_18f_gov_cname" {
   records = ["d189ghshxys967.cloudfront.net"]
 }
 
-resource "aws_route53_record" "18f_gov_federalistapp_18f_gov_cname" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "federalistapp.18f.gov."
-  type = "CNAME"
-  ttl = 60
-  records = ["d189ghshxys967.cloudfront.net"]
-}
-
 resource "aws_route53_record" "18f_gov_federalist-staging_18f_gov_cname" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "federalist-staging.18f.gov."


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.
