### PR TITLE
add tophealth.pif.gov

### DIFF
--- a/terraform/pif.gov.tf
+++ b/terraform/pif.gov.tf
@@ -140,6 +140,14 @@ resource "aws_route53_record" "paygap_pif_cname" {
   records = ["d2qm19v1sj7zt0.cloudfront.net"]
 }
 
+resource "aws_route53_record" "tophealth_pif_cname" {
+  zone_id = "${aws_route53_zone.pif_toplevel.zone_id}"
+  name = "tophealth.pif.gov."
+  type = "CNAME"
+  ttl = 300
+  records = ["d2c5jlxyl3tdbm.cloudfront.net"]
+}
+
 resource "aws_route53_record" "review_cname" {
   zone_id = "${aws_route53_zone.pif_toplevel.zone_id}"
   name = "review.pif.gov."


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.
