### PR TITLE
Removing recalls.pif.gov

### DIFF
--- a/terraform/pif.gov.tf
+++ b/terraform/pif.gov.tf
@@ -116,14 +116,6 @@ resource "aws_route53_record" "proposal_cname" {
   records = ["proposal.pif.gov.00du0000000leuxmac.live.siteforce.com"]
 }
 
-resource "aws_route53_record" "recalls_cname" {
-  zone_id = "${aws_route53_zone.pif_toplevel.zone_id}"
-  name = "recalls.pif.gov."
-  type = "CNAME"
-  ttl = 300
-  records = ["presidential-innovation-fellows.github.io"]
-}
-
 resource "aws_route53_record" "fellows_in_innovation_pif_cname" {
   zone_id = "${aws_route53_zone.pif_toplevel.zone_id}"
   name = "fellows-in-innovation.pif.gov."


### PR DESCRIPTION
@erik-burgess taking down the site at the request of GSA IT Security. Github Pages is not currently compliant with HSTS requirements.

PRs affecting a Federalist site must receive approval from a member of the relevant team.
