### PR TITLE
Updating zone id for public-sans.digital.gov

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -113,7 +113,7 @@ resource "aws_route53_record" "public_sans_digital_gov_aaaa" {
   type = "A"
   alias {
     name = "d3t8f8c09txt9n.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -108,7 +108,7 @@ resource "aws_route53_record" "components_designsystem_digital_gov_aaaa" {
 
 # public-sans.digital.gov — A
 resource "aws_route53_record" "public_sans_digital_gov_aaaa" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
   name = "public-sans.digital.gov."
   type = "A"
   alias {


### PR DESCRIPTION
As @amirbey pointed out, the zone_id was not correct.
This fixes that hopefully.

PRs affecting a Federalist site must receive approval from a member of the relevant team.
