### PR TITLE
set modularcontracting with custom domain

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -984,6 +984,14 @@ resource "aws_route53_record" "18f_gov_e2e080f495caf881194dadb62fb3d5bc_18f_gov_
   records = ["25aad757d26409f9b764f267283fda0ec6e8e3f1.comodoca.com."]
 }
 
+resource "aws_route53_record" "18f_gov_modularcontracting_18f_gov_a" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "modularcontracting.18f.gov."
+  type = "CNAME"
+  ttl = 300
+  records = ["production-domains-1-884689640.us-gov-west-1.elb.amazonaws.com."]
+}
+
 output "18f_gov_ns" {
   value="${aws_route53_zone.18f_gov_zone.name_servers}"
 }


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.
