### PR TITLE
pin docker image for plan job of circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
 
   apply:
     docker:
-      - image: hashicorp/terraform:light
+      - image: hashicorp/terraform:0.11.14
     steps:
       - attach_workspace:
           at: .


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.
#331 

the docker image for the "apply" circle job must also be modified