### PR TITLE
add MX priority

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -297,7 +297,7 @@ resource "aws_route53_record" "demo_app_touchpoints_digital_gov_mx" {
   type = "MX"
   ttl = "600"
   records = [
-    "inbound-smtp.us-east-1.amazonaws.com"
+    "10 inbound-smtp.us-east-1.amazonaws.com"
   ]
 }
 
@@ -368,7 +368,7 @@ resource "aws_route53_record" "touchpoints_digital_gov_mx" {
   type = "MX"
   ttl = "600"
   records = [
-    "inbound-smtp.us-east-1.amazonaws.com"
+    "10 inbound-smtp.us-east-1.amazonaws.com"
   ]
 }
 


### PR DESCRIPTION
* to address build failure MXRRDATANotTwoFields (MX record doesn't have 2 fields)

PRs affecting a Federalist site must receive approval from a member of the relevant team.
