### PR TITLE
fixing a bug in hubspot CNAME

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -344,7 +344,7 @@ resource "aws_route53_record" "hubspot2_digitalgov_gov_a" {
   type    = "CNAME"
   ttl     = "300"
   records = [
-    "digitalgov-gov.hs01a.dkim.hubspotemail.net."
+    "digitalgov-gov.hs01b.dkim.hubspotemail.net."
   ]
 }
 


### PR DESCRIPTION
Fixing an error with our **hubspot2_digitalgov_gov_a** record:
It was off by one character.

Should be `digitalgov-gov.hs01b.dkim.hubspotemail.net.`


---

PRs affecting a Federalist site must receive approval from a member of the relevant team.
