### PR TITLE
Adding Hubspot records for Digital.gov

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -375,12 +375,15 @@ resource "aws_route53_record" "touchpoints_digital_gov_mx" {
 # Compliance and ACME records -------------------------------
 
 # BOD
+
 resource "aws_route53_record" "digital_gov_dmarc_digital_gov_txt" {
   zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
   name    = "digital.gov."
   type    = "TXT"
   ttl     = 300
-  records = ["${local.spf_no_mail}"]
+  records = [
+    "v=spf1 include:1962994m.challenge.gov ~all"
+  ]
 }
 
 # v2.designsystem.digital.gov TXT / ACME Challenge
@@ -459,7 +462,6 @@ resource "aws_route53_record" "touchpoints_digital_gov__acme-challenge_txt" {
 # EMAIL NEWSLETTER (HubSpot)
 
 # Hubspot records for sending email from the digital.gov domain
-# See https://knowledge.hubspot.com/email/can-i-use-a-dmarc-policy-with-hubspot#troubleshoot-issues-with-dmarc-authentication
 resource "aws_route53_record" "hubspot1_digital_gov_a" {
   zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
   name    = "hs1._domainkey.digital.gov."
@@ -471,7 +473,6 @@ resource "aws_route53_record" "hubspot1_digital_gov_a" {
 }
 
 # Hubspot records for sending email from the digital.gov domain
-# See https://knowledge.hubspot.com/email/can-i-use-a-dmarc-policy-with-hubspot#troubleshoot-issues-with-dmarc-authentication
 resource "aws_route53_record" "hubspot2_digital_gov_a" {
   zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
   name    = "hs2._domainkey.digital.gov."

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -381,9 +381,7 @@ resource "aws_route53_record" "digital_gov_dmarc_digital_gov_txt" {
   name    = "digital.gov."
   type    = "TXT"
   ttl     = 300
-  records = [
-    "v=spf1 include:1962994.spf05.hubspotemail.net ~all"
-  ]
+  records = ["${local.spf_hubspot}"]
 }
 
 # v2.designsystem.digital.gov TXT / ACME Challenge

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -454,6 +454,50 @@ resource "aws_route53_record" "touchpoints_digital_gov__acme-challenge_txt" {
   records = ["Ho5lFIaJK7J44nLyBWGpfMBRNc96eL7-QnMuBII-4Uc"]
 }
 
+# =================================
+
+# EMAIL NEWSLETTER (HubSpot)
+
+# Hubspot records for sending email from the digital.gov domain
+# See https://knowledge.hubspot.com/email/can-i-use-a-dmarc-policy-with-hubspot#troubleshoot-issues-with-dmarc-authentication
+resource "aws_route53_record" "hubspot1_digital_gov_a" {
+  zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
+  name    = "hs1._domainkey.digital.gov."
+  type    = "CNAME"
+  ttl     = "300"
+  records = [
+    "digital-gov.hs01a.dkim.hubspotemail.net."
+  ]
+}
+
+# Hubspot records for sending email from the digital.gov domain
+# See https://knowledge.hubspot.com/email/can-i-use-a-dmarc-policy-with-hubspot#troubleshoot-issues-with-dmarc-authentication
+resource "aws_route53_record" "hubspot2_digital_gov_a" {
+  zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
+  name    = "hs2._domainkey.digital.gov."
+  type    = "CNAME"
+  ttl     = "300"
+  records = [
+    "digital-gov.hs01b.dkim.hubspotemail.net."
+  ]
+}
+
+# Hubspot TXT records for sending email from the digital.gov domain
+resource "aws_route53_record" "hubspot_digital_gov_txt" {
+  zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
+  name    = "smtpapi._domainkey.digital.gov."
+  type    = "TXT"
+  ttl     = "300"
+  records = [
+    "k=rsa; t=s; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDPtW5iwpXVPiH5FzJ7Nrl8USzuY9zqqzjE0D1r04xDN6qwziDnmgcFNNfMewVKN2D1O+2J9N14hRprzByFwfQW76yojh54Xu3uSbQ3JP0A7k8o8GutRF8zbFUA8n0ZH2y0cIEjMliXY4W4LwPA7m4q0ObmvSjhd63O9d8z1XkUBwIDAQAB"
+  ]
+}
+
+
+# END EMAIL NEWSLETTER (HubSpot)
+
+# =================================
+
 output "digital_ns" {
   value = "${aws_route53_zone.digital_toplevel.name_servers}"
 }

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -382,7 +382,7 @@ resource "aws_route53_record" "digital_gov_dmarc_digital_gov_txt" {
   type    = "TXT"
   ttl     = 300
   records = [
-    "v=spf1 include:1962994m.challenge.gov ~all"
+    "v=spf1 include:1962994.spf05.hubspotemail.net ~all"
   ]
 }
 

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -404,7 +404,7 @@ resource "aws_route53_record" "digitalgov_gov_dmarc_digitalgov_gov_txt" {
   name    = "digitalgov.gov."
   type    = "TXT"
   ttl     = 300
-  records = ["${local.spf_no_mail}"]
+  records = ["${local.spf_hubspot}"]
 }
 
 resource "aws_route53_record" "digitalgov_gov__dmarc_digitalgov_gov_txt" {

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -22,4 +22,5 @@ locals {
   dmarc_reject = "v=DMARC1; p=reject; pct=100; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
 
   spf_no_mail = "v=spf1 -all"
+  spf_hubspot = "v=spf1 include:1962994.spf05.hubspotemail.net ~all"
 }


### PR DESCRIPTION
This change adds in the Hubspot records for **Digital.gov**


### Hubspot DNS records for Digital.gov 

```
# Hubspot records for sending email from the digital.gov domain
resource "aws_route53_record" "hubspot1_digital_gov_a" {
  zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
  name    = "hs1._domainkey.digital.gov."
  type    = "CNAME"
  ttl     = "300"
  records = [
    "digital-gov.hs01a.dkim.hubspotemail.net."
  ]
}

# Hubspot records for sending email from the digital.gov domain
resource "aws_route53_record" "hubspot2_digital_gov_a" {
  zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
  name    = "hs2._domainkey.digital.gov."
  type    = "CNAME"
  ttl     = "300"
  records = [
    "digital-gov.hs01b.dkim.hubspotemail.net."
  ]
}

# Hubspot TXT records for sending email from the digital.gov domain
resource "aws_route53_record" "hubspot_digital_gov_txt" {
  zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
  name    = "smtpapi._domainkey.digital.gov."
  type    = "TXT"
  ttl     = "300"
  records = [
    "k=rsa; t=s; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDPtW5iwpXVPiH5FzJ7Nrl8USzuY9zqqzjE0D1r04xDN6qwziDnmgcFNNfMewVKN2D1O+2J9N14hRprzByFwfQW76yojh54Xu3uSbQ3JP0A7k8o8GutRF8zbFUA8n0ZH2y0cIEjMliXY4W4LwPA7m4q0ObmvSjhd63O9d8z1XkUBwIDAQAB"
  ]
}
```

### Modified SPF records for Digital.gov

We are changing our SPF record to include the Hubspot IP address.

It was `v=spf1 -all` (included via the variable below):
```
records = ["${local.spf_no_mail}"]
```
and is now changed to:
```
records = [
   "v=spf1 include:1962994m.challenge.gov ~all"
]
```

---

PRs affecting a Federalist site must receive approval from a member of the relevant team.
