### PR TITLE
Adding HubSpot IP to digitalgov.gov SPF record

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -404,7 +404,9 @@ resource "aws_route53_record" "digitalgov_gov_dmarc_digitalgov_gov_txt" {
   name    = "digitalgov.gov."
   type    = "TXT"
   ttl     = 300
-  records = ["${local.spf_no_mail}"]
+  records = [
+    "v=spf1 include:1962994m.challenge.gov ~all"
+  ]
 }
 
 resource "aws_route53_record" "digitalgov_gov__dmarc_digitalgov_gov_txt" {

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -405,7 +405,7 @@ resource "aws_route53_record" "digitalgov_gov_dmarc_digitalgov_gov_txt" {
   type    = "TXT"
   ttl     = 300
   records = [
-    "v=spf1 include:1962994m.challenge.gov ~all"
+    "v=spf1 include:1962994.spf05.hubspotemail.net ~all"
   ]
 }
 


### PR DESCRIPTION
Editing the SPF record for DigitalGov.gov to include the HubSpot dedicated IP for our account.

**currently set to** `v=spf1 -all` via a variable in the file
```
records = [
    "v=spf1 -all"
]
```

**changing to:**
```
records = [
    "v=spf1 include:1962994.spf05.hubspotemail.net ~all"
]
```

related to https://github.com/GSA/digitalgov.gov/issues/1513#issuecomment-576786606

---

PRs affecting a Federalist site must receive approval from a member of the relevant team.
