### PR TITLE
Adding Google site verification

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -381,7 +381,10 @@ resource "aws_route53_record" "digital_gov_dmarc_digital_gov_txt" {
   name    = "digital.gov."
   type    = "TXT"
   ttl     = 300
-  records = ["${local.spf_hubspot}"]
+  records = [
+    "google-site-verification=Mi2rwVMxdp3eSbZughKvN0M_dwi6WLxMrRSsnLOWyVI",
+    "${local.spf_hubspot}"
+  ]
 }
 
 # v2.designsystem.digital.gov TXT / ACME Challenge

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -404,7 +404,10 @@ resource "aws_route53_record" "digitalgov_gov_dmarc_digitalgov_gov_txt" {
   name    = "digitalgov.gov."
   type    = "TXT"
   ttl     = 300
-  records = ["${local.spf_hubspot}"]
+  records = [
+    "google-site-verification=WRPUo6XC7m4X-8jJFvXPVs-W4uiqfEbF-pQYcD1-MOU",
+    "${local.spf_hubspot}"
+  ]
 }
 
 resource "aws_route53_record" "digitalgov_gov__dmarc_digitalgov_gov_txt" {


### PR DESCRIPTION
This change adds in Google Site Verification via https://postmaster.google.com/

Background: https://support.google.com/mail/answer/2451690 and https://support.google.com/mail/answer/6227174

PRs affecting a Federalist site must receive approval from a member of the relevant team.
