### PR TITLE
temp remove handbook.18f.gov for redirect prep

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -642,14 +642,6 @@ resource "aws_route53_record" "18f_gov_guides-template_18f_gov_a" {
   }
 }
 
-resource "aws_route53_record" "18f_gov_handbook_18f_gov_a" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "handbook.18f.gov."
-  type = "CNAME"
-  ttl = 300
-  records = ["dtj4n4imxei9y.cloudfront.net"]
-}
-
 resource "aws_route53_record" "18f_gov_iaa-forms_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "iaa-forms.18f.gov."


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.
