### PR TITLE
add handbook.18f.gov to redirect app

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -1040,6 +1040,25 @@ resource "aws_route53_record" "18f_gov_amirbey_test_cdn_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "18f_gov__acme-challenge_handbook_18f_gov_txt" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "_acme-challenge.handbook.18f.gov."
+  type = "TXT"
+  ttl = 120
+  records = ["OH0DsfnJBEZTUlRZ-Gie1zLnHN-gPD5RLKYOdrDfFd4"]
+}
+
+resource "aws_route53_record" "18f_gov_handbook_18f_gov_a" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "handbook.18f.gov."
+  type = "A"
+  alias {
+    name = "d3bxe02ezqs8zq.cloudfront.net."
+    zone_id = "${local.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
 output "18f_gov_ns" {
   value="${aws_route53_zone.18f_gov_zone.name_servers}"
 }


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.
