### PR TITLE
remove frontend.18f.gov to create pages_redirect cdn

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -557,17 +557,6 @@ resource "aws_route53_record" "18f_gov_files_18f_gov_a" {
   }
 }
 
-resource "aws_route53_record" "18f_gov_frontend_18f_gov_a" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "frontend.18f.gov."
-  type = "A"
-  alias {
-    name = "d2dhxnk13yje6c.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
-}
-
 resource "aws_route53_record" "18f_gov_fugacious_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "fugacious.18f.gov."


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.
