### PR TITLE
HOLD till 3/22 @ 12pm ET — Update the U.S. Digital Registry record

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -127,7 +127,7 @@ resource "aws_route53_record" "usdigitalregistry_digitalgov_gov_a" {
   type    = "CNAME"
   ttl     = "300"
   records = [
-    "alb-scmdrg-prod-digitalgov-pub-1-1069371853.us-east-1.elb.amazonaws.com."
+    "alb-smr-prod-pub-2-970074805.us-east-1.elb.amazonaws.com."
   ]
 }
 


### PR DESCRIPTION
⚠️ **HOLD till 3/22 @ 12pm ET**

Per a request from members of the GSA IT team —

```
We are migrating our environment to be hosted by REI (ECAS). We were planning to have a DNS change that needs to be made to the digitalgov.gov doman on Sun, 3/22 at 12:00 pm (Noon)

We discovered we do not have control of the digitalgov.gov doman and need to change the dns record

The change that need to be made is:
usdigitalregistry.digitalgov.gov  300 IN  CNAME    alb-smr-prod-pub-2-970074805.us-east-1.elb.amazonaws.com
We were hoping that you could assist.
Please let me know.  Thanks.
```

---

_PRs affecting a Federalist site must receive approval from a member of the relevant team._
