### PR TITLE
Adding the usability.gov record

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,0 @@
-PRs affecting a Federalist site must receive approval from a member of the relevant team.

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -1119,6 +1119,25 @@ resource "aws_route53_record" "18f_gov__acme-challenge_federalist-proxysite-test
   records = ["qiz18V0W9mHROFHTHqE4_Bn8NIByqMhoLvkKQ3h4Zxg"]
 }
 
+resource "aws_route53_record" "18f_gov_ux-guide_18f_gov_a" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "ux-guide.18f.gov."
+  type = "A"
+  alias {
+    name = "d2mhwjcivqpysk.cloudfront.net."
+    zone_id = "${local.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "18f_gov__acme-challenge_ux-guide_18f_gov_txt" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "_acme-challenge.ux-guide.18f.gov."
+  type = "TXT"
+  ttl = 120
+  records = ["cMHSS7E7SJghSFKvmy-K8Cp78eZ8ihZjzESAuyEi5eY"]
+}
+
 output "18f_gov_ns" {
   value="${aws_route53_zone.18f_gov_zone.name_servers}"
 }

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "18f_gov_18f_gov_a" {
   type = "A"
   alias {
     name = "d1undivnru8ry9.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -80,7 +80,7 @@ resource "aws_route53_record" "18f_gov_accessibility_18f_gov_a" {
   type = "A"
   alias {
     name = "d3gg23ftaba0j8.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -91,7 +91,7 @@ resource "aws_route53_record" "18f_gov_ads_18f_gov_a" {
   type = "A"
   alias {
     name = "d22116wmhcds2y.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -110,7 +110,7 @@ resource "aws_route53_record" "18f_gov_agile_18f_gov_a" {
   type = "A"
   alias {
     name = "d2zsago6kfzgka.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -121,7 +121,7 @@ resource "aws_route53_record" "18f_gov_agile-labor-categories_18f_gov_a" {
   type = "A"
   alias {
     name = "d1p2fryyhm3d02.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -140,7 +140,7 @@ resource "aws_route53_record" "18f_gov_acqstack-journeymap_18f_gov_a" {
   type = "A"
   alias {
     name = "douocfsg4z7b4.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -159,7 +159,7 @@ resource "aws_route53_record" "18f_gov_api-all-the-x_18f_gov_a" {
   type = "A"
   alias {
     name = "d2y8d8116udf0m.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -170,7 +170,7 @@ resource "aws_route53_record" "18f_gov_api-program_18f_gov_a" {
   type = "A"
   alias {
     name = "d1evjsspb8gisi.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -181,7 +181,7 @@ resource "aws_route53_record" "18f_gov_api-usability-testing_18f_gov_a" {
   type = "A"
   alias {
     name = "d1lsalt1zbpjfm.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -200,7 +200,7 @@ resource "aws_route53_record" "18f_gov_atul-docker-presentation_18f_gov_a" {
   type = "A"
   alias {
     name = "dndsei0n82g4z.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -219,7 +219,7 @@ resource "aws_route53_record" "18f_gov_automated-testing-playbook_18f_gov_a" {
   type = "A"
   alias {
     name = "dieiwe9bk9l6.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -230,7 +230,7 @@ resource "aws_route53_record" "18f_gov_blogging-guide_18f_gov_cname" {
   type = "A"
   alias {
     name = "d12gmeaikmi2zi.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -241,7 +241,7 @@ resource "aws_route53_record" "18f_gov_before-you-ship_18f_gov_a" {
   type = "A"
   alias {
     name = "daap61vtgsw76.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -252,7 +252,7 @@ resource "aws_route53_record" "18f_gov_boise_18f_gov_a" {
   type = "A"
   alias {
     name = "d2swak4c9i5bze.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -271,7 +271,7 @@ resource "aws_route53_record" "18f_gov_brand_18f_gov_a" {
   type = "A"
   alias {
     name = "d19y688vepyspr.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -322,7 +322,7 @@ resource "aws_route53_record" "18f_gov_climate-data-user-study_18f_gov_a" {
   type = "A"
   alias {
     name = "d28r76t17zvn4f.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -341,7 +341,7 @@ resource "aws_route53_record" "18f_gov_content-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "dv941ubd2f1ex.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -352,7 +352,7 @@ resource "aws_route53_record" "18f_gov_contracting-cookbook_18f_gov_a" {
   type = "A"
   alias {
     name = "d20pvyni7jlo89.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -371,7 +371,7 @@ resource "aws_route53_record" "18f_gov_design-principles-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "d3g58t13quzfbr.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -382,7 +382,7 @@ resource "aws_route53_record" "18f_gov_digital-acquisition-playbook_18f_gov_a" {
   type = "A"
   alias {
     name = "d3f32ju5qz0fej.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -393,7 +393,7 @@ resource "aws_route53_record" "18f_gov_digitalaccelerator_18f_gov_a" {
   type = "A"
   alias {
     name = "dmsaspwnb8oe8.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -420,7 +420,7 @@ resource "aws_route53_record" "18f_gov_eng-hiring_18f_gov_a" {
   type = "A"
   alias {
     name = "d1ju28lhpbkq84.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -471,7 +471,7 @@ resource "aws_route53_record" "18f_gov_federalist-docs_18f_gov_a" {
   type = "A"
   alias {
     name = "d5s9igq4dqiuh.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -490,7 +490,7 @@ resource "aws_route53_record" "18f_gov_federalist-docs-staging_18f_gov_a" {
   type = "A"
   alias {
     name = "d32ywxpmz9thx7.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -533,7 +533,7 @@ resource "aws_route53_record" "18f_gov_files_18f_gov_a" {
   type = "A"
   alias {
     name = "d3gawctq7ecsbu.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -544,7 +544,7 @@ resource "aws_route53_record" "18f_gov_fugacious_18f_gov_a" {
   type = "A"
   alias {
     name = "d309sw0ah4sgku.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -563,7 +563,7 @@ resource "aws_route53_record" "18f_gov_govconnect_18f_gov_a" {
   type = "A"
   alias {
     name = "d1pr8zgciesx6n.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -585,7 +585,7 @@ resource "aws_route53_record" "18f_gov_grouplet-playbook_18f_gov_a" {
   type = "A"
   alias {
     name = "duek7xmosg5g1.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -596,7 +596,7 @@ resource "aws_route53_record" "18f_gov_guides_18f_gov_a" {
   type = "A"
   alias {
     name = "d10jxiv8e4xcp7.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -607,7 +607,7 @@ resource "aws_route53_record" "18f_gov_guides-template_18f_gov_a" {
   type = "A"
   alias {
     name = "d2qsfvvx1xjk0n.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -618,7 +618,7 @@ resource "aws_route53_record" "18f_gov_iaa-forms_18f_gov_a" {
   type = "A"
   alias {
     name = "d25t6p0vmr5bdy.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -629,7 +629,7 @@ resource "aws_route53_record" "18f_gov_identity-dev-docs_18f_gov_a" {
   type = "A"
   alias {
     name = "d35rhrbvrsocmo.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -640,7 +640,7 @@ resource "aws_route53_record" "18f_gov_innovation-toolkit-prototype_18f_gov_a" {
   type = "A"
   alias {
     name = "d1n516riijd335.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -662,7 +662,7 @@ resource "aws_route53_record" "18f_gov_lean-product-design_18f_gov_a" {
   type = "A"
   alias {
     name = "d3am6kz2e8wzjv.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -684,7 +684,7 @@ resource "aws_route53_record" "18f_gov_methods_18f_gov_a" {
   type = "A"
   alias {
     name = "d2z1u02mjhp26x.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -696,7 +696,7 @@ resource "aws_route53_record" "18f_gov_micropurchase_18f_gov_a" {
   type = "A"
   alias {
     name = "dh692qtc0b17x.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -715,7 +715,7 @@ resource "aws_route53_record" "18f_gov_open-source-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "d1lphbkymflb0f.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -726,7 +726,7 @@ resource "aws_route53_record" "18f_gov_open-source-program_18f_gov_a" {
   type = "A"
   alias {
     name = "d3nhr6mr0xvquu.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -745,7 +745,7 @@ resource "aws_route53_record" "18f_gov_paid-leave-prototype_18f_gov_a" {
   type = "A"
   alias {
     name = "d3p6d6b3zaatqv.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -764,7 +764,7 @@ resource "aws_route53_record" "18f_gov_partnership-playbook_18f_gov_a" {
   type = "A"
   alias {
     name = "d19eih1husc7rz.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -775,7 +775,7 @@ resource "aws_route53_record" "18f_gov_performance-gov-research_18f_gov_a" {
   type = "A"
   alias {
     name = "d3csg01izjywi2.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -786,7 +786,7 @@ resource "aws_route53_record" "18f_gov_plain-language-tutorial_18f_gov_a" {
   type = "A"
   alias {
     name = "d1cr44lbvuvjia.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -797,7 +797,7 @@ resource "aws_route53_record" "18f_gov_private-eye_18f_gov_a" {
   type = "A"
   alias {
     name = "d3asgf5hc4zmll.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -808,7 +808,7 @@ resource "aws_route53_record" "18f_gov_product-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "d2ys0ic6txy8sy.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -835,7 +835,7 @@ resource "aws_route53_record" "18f_gov_testing-cookbook_18f_gov_a" {
   type = "A"
   alias {
     name = "d3r30wgm96hxdb.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -854,7 +854,7 @@ resource "aws_route53_record" "18f_gov_writing-lab-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "d1pjk83agbp9qr.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -865,7 +865,7 @@ resource "aws_route53_record" "18f_gov_www_18f_gov_a" {
   type = "A"
   alias {
     name = "d1undivnru8ry9.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -900,7 +900,7 @@ resource "aws_route53_record" "18f_gov_agile-bpa_18f_gov_a" {
   type = "A"
   alias {
     name = "d2f0yvhrnh42o8.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -919,7 +919,7 @@ resource "aws_route53_record" "18f_gov_fedspendingtransparency_18f_gov_a" {
   type = "A"
   alias {
     name = "d3fi39fc24yqlx.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -938,7 +938,7 @@ resource "aws_route53_record" "18f_gov_slides_18f_gov_a" {
   type = "A"
   alias {
     name = "d1g4r1oppplum4.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -981,7 +981,7 @@ resource "aws_route53_record" "18f_gov_engineering_18f_gov_a" {
   type = "A"
   alias {
     name = "d1ah19wbgikahf.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1000,7 +1000,7 @@ resource "aws_route53_record" "18f_gov_handbook_18f_gov_a" {
   type = "A"
   alias {
     name = "d36dwgrf0cle4t.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1019,7 +1019,7 @@ resource "aws_route53_record" "18f_gov_www_handbook_18f_gov_a" {
   type = "A"
   alias {
     name = "d36dwgrf0cle4t.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1038,7 +1038,7 @@ resource "aws_route53_record" "18f_gov_sites-dev_federalist_18f_gov_a" {
   type = "A"
   alias {
     name = "d2engtqzi489lh.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1049,7 +1049,7 @@ resource "aws_route53_record" "18f_gov_frontend_18f_gov_a" {
   type = "A"
   alias {
     name = "degmwhx2dki4o.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1068,7 +1068,7 @@ resource "aws_route53_record" "18f_gov_federalist_report_template_18f_gov_a" {
   type = "A"
   alias {
     name = "d25aquneuwyx3x.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1087,7 +1087,7 @@ resource "aws_route53_record" "18f_gov_demo-er2epz2vb_18f_gov_a" {
   type = "A"
   alias {
     name = "djut57wuzit2q.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1106,7 +1106,7 @@ resource "aws_route53_record" "18f_gov_federalist-proxysite-test_18f_gov_a" {
   type = "A"
   alias {
     name = "d1p5ay1q619hg3.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -1125,7 +1125,7 @@ resource "aws_route53_record" "18f_gov_ux-guide_18f_gov_a" {
   type = "A"
   alias {
     name = "d2mhwjcivqpysk.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -90,10 +90,18 @@ resource "aws_route53_record" "18f_gov_ads_18f_gov_a" {
   name = "ads.18f.gov."
   type = "A"
   alias {
-    name = "d1p50apr0w92d2.cloudfront.net."
+    name = "d22116wmhcds2y.cloudfront.net."
     zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
+}
+
+resource "aws_route53_record" "18f_gov__acme-challenge_ads_18f_gov_txt" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "_acme-challenge.ads.18f.gov."
+  type = "TXT"
+  ttl = 120
+  records = ["fXfES1KVPHxh87Y9iMVwl_ezEGRpKagAL7EzQpuYaBI"]
 }
 
 resource "aws_route53_record" "18f_gov_agile_18f_gov_a" {
@@ -744,7 +752,7 @@ resource "aws_route53_record" "18f_gov_paid-leave-prototype_18f_gov_a" {
   name = "paid-leave-prototype.18f.gov."
   type = "A"
   alias {
-    name = "d1tgknd7unaxw4.cloudfront.net."
+    name = "d3p6d6b3zaatqv.cloudfront.net."
     zone_id = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -755,7 +763,7 @@ resource "aws_route53_record" "18f_gov__acme-challenge_paid_leave_prototype_18f_
   name = "_acme-challenge.paid-leave-prototype.18f.gov."
   type = "TXT"
   ttl = 120
-  records = ["PP01ymh2DTBj32M5vQLIIwwY0Nr6CVK12yu3oAnFcwg"]
+  records = ["Rll4MS51zYr9CmfUEjs-0G5HExXnuQiyM_8MBjskIuw"]
 }
 
 resource "aws_route53_record" "18f_gov_partnership-playbook_18f_gov_a" {

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -398,14 +398,6 @@ resource "aws_route53_record" "18f_gov_digitalaccelerator_18f_gov_a" {
   }
 }
 
-resource "aws_route53_record" "18f_gov_dnssec_18f_gov_ns" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "dnssec.18f.gov."
-  type = "NS"
-  ttl = 300
-  records = ["hope.ns.cloudflare.com", "phil.ns.cloudflare.com"]
-}
-
 resource "aws_route53_record" "18f_gov_dolores_app_18f_gov_cname" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name = "dolores-app.18f.gov."

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -1015,7 +1015,7 @@ resource "aws_route53_record" "18f_gov__acme-challenge_www_handbook_18f_gov_txt"
 
 resource "aws_route53_record" "18f_gov_www_handbook_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "www.handbook.18f.gov."
+  name = "wwwhandbook.18f.gov."
   type = "A"
   alias {
     name = "d36dwgrf0cle4t.cloudfront.net."

--- a/terraform/analytics.usa.gov.tf
+++ b/terraform/analytics.usa.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "analytics_usa_gov_analytics_usa_gov_a" {
 
   alias {
     name                   = "d2rprfiomwib2l.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/apps.gov.tf
+++ b/terraform/apps.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "apps_gov_apps_gov_a" {
   type    = "A"
   alias {
     name                   = "d24f99alwtdu0h.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -86,7 +86,7 @@ resource "aws_route53_record" "apps_gov_www_apps_gov_a" {
   type    = "A"
   alias {
     name                   = "d24f99alwtdu0h.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/calc.gsa.gov.tf
+++ b/terraform/calc.gsa.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "calc_gsa_gov_calc_gsa_gov_a" {
 
   alias {
     name                   = "d3ulj13shqrbkv.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "code_gov_apex" {
 
   alias {
     name                   = "dqziuvpgrykcy.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -25,7 +25,7 @@ resource "aws_route53_record" "code_gov_www" {
 
   alias {
     name                   = "dqziuvpgrykcy.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -37,7 +37,7 @@ resource "aws_route53_record" "staging_code_gov_a" {
 
   alias {
     name                   = "d3g0jy911fqt1l.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -49,7 +49,7 @@ resource "aws_route53_record" "code_gov_developers_code_gov_a" {
 
   alias {
     name                   = "d3jsj3d37agtw.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/collegescorecard.ed.gov.tf
+++ b/terraform/collegescorecard.ed.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "collegescorecard_ed_gov_collegescorecard_ed_gov_a
 
   alias {
     name                   = "d1a8vwb3lfw7jl.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/connect.gov.tf
+++ b/terraform/connect.gov.tf
@@ -12,7 +12,7 @@ resource "aws_route53_record" "connect_gov_connect_gov_a" {
 
   alias {
     name                   = "d1tqmxfevhun0x.cloudfront.net"
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = true
   }
 }
@@ -23,7 +23,7 @@ resource "aws_route53_record" "www_connect_gov_connect_gov_cname" {
   type    = "A"
   alias {
     name                   = "d1tqmxfevhun0x.cloudfront.net"
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = true
   }
 }

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -19,7 +19,7 @@ resource "aws_route53_record" "digital_gov_apex" {
 
   alias {
     name                   = "d2q1i25any8vwy.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -32,7 +32,7 @@ resource "aws_route53_record" "digital_gov_www" {
 
   alias {
     name                   = "d11gdxqvugzxkr.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -45,7 +45,7 @@ resource "aws_route53_record" "demo_digital_gov_a" {
 
   alias {
     name                   = "d1f2igtqmwwbgm.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -58,7 +58,7 @@ resource "aws_route53_record" "workflow_digital_gov_a" {
 
   alias {
     name                   = "d1m1gatn2ksd43.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -160,7 +160,7 @@ resource "aws_route53_record" "public_sans_digital_gov_a" {
   type    = "A"
   alias {
     name                   = "d30jruftdogur6.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -239,7 +239,7 @@ resource "aws_route53_record" "demo_touchpoints_digital_gov_a" {
   type    = "A"
   alias {
     name                   = "dcxk3q3d8gzx7.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -310,7 +310,7 @@ resource "aws_route53_record" "touchpoints_digital_gov_a" {
   type    = "A"
   alias {
     name                   = "d5n0pmq4ueiac.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -73,7 +73,7 @@ resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_a" {
   type    = "A"
   alias {
     name                   = "d198punmzgrl9l.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/discovery.gsa.gov.tf
+++ b/terraform/discovery.gsa.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "discovery_gsa_gov_discovery_gsa_gov_a" {
 
   alias {
     name                   = "d11du9vova78yj.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/everykidinapark.gov.tf
+++ b/terraform/everykidinapark.gov.tf
@@ -12,7 +12,7 @@ resource "aws_route53_record" "everykidinapark_gov_everykidinapark_gov_a" {
   type    = "A"
   alias {
     name                   = "d356so74a5xncl.cloudfront.net"
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -24,7 +24,7 @@ resource "aws_route53_record" "everykidinapark_gov_www_everykidinapark_gov_a" {
   type    = "A"
   alias {
     name                   = "d356so74a5xncl.cloudfront.net"
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/https.cio.gov.tf
+++ b/terraform/https.cio.gov.tf
@@ -14,7 +14,7 @@ resource "aws_route53_record" "https_cio_gov_https_cio_gov_a" {
 
   alias {
     name                   = "d2h7trd5jt3vay.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -11,11 +11,6 @@ terraform {
 }
 
 locals {
-  // Unclear where this value comes from; presumably it's a deprecated value from AWS. -Aidan Feldman, 11/6/17
-  old_cloudfront_zone_id = "Z33AYJ8TM3BH4J"
-
-  // https://docs.aws.amazon.com/general/latest/gr/rande.html#cf_region
-  cloudfront_zone_id = "Z2FDTNDATAQYW2"
   // https://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region
   elb_zone_id = "Z35SXDOTRQ7X7K"
 

--- a/terraform/innovation.gov.tf
+++ b/terraform/innovation.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "innovation_gov_apex" {
 
   alias {
     name                   = "d2ntl68ywjm643.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -25,7 +25,7 @@ resource "aws_route53_record" "innovation_gov_www" {
 
   alias {
     name                   = "d2ntl68ywjm643.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -37,7 +37,7 @@ resource "aws_route53_record" "demo_innovation_gov_a" {
 
   alias {
     name                   = "d3am9l7wwd0yie.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/open.foia.gov.tf
+++ b/terraform/open.foia.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "open_foia_gov_open_foia_gov_a" {
 
   alias {
     name                   = "d23kapr45ru7n0.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/pif.gov.tf
+++ b/terraform/pif.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "www" {
 
   alias {
     name                   = "dgevgiwb7xxpw.cloudfront.net"
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -155,7 +155,7 @@ resource "aws_route53_record" "www-main" {
 
   alias {
     name                   = "dgevgiwb7xxpw.cloudfront.net"
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/presidentialinnovationfellows.gov.tf
+++ b/terraform/presidentialinnovationfellows.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "presidentialinnovationfellows_www" {
 
   alias {
     name                   = "d26prp92rpqmzl.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -25,7 +25,7 @@ resource "aws_route53_record" "presidentialinnovationfellows_apex" {
 
   alias {
     name                   = "d26prp92rpqmzl.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/pulse.cio.gov.tf
+++ b/terraform/pulse.cio.gov.tf
@@ -18,7 +18,7 @@ resource "aws_route53_record" "pulse_cio_gov_pulse_cio_gov_a" {
 
   alias {
     name                   = "${local.pulse_cloudfront}"
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -30,7 +30,7 @@ resource "aws_route53_record" "pulse_cio_gov_pulse_cio_gov_aaaa" {
 
   alias {
     name                   = "${local.pulse_cloudfront}"
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/sbst.gov.tf
+++ b/terraform/sbst.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "sbst_gov_sbst_gov_a" {
 
   alias {
     name                   = "d277n30llb5z4h.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -25,7 +25,7 @@ resource "aws_route53_record" "sbst_gov_sbst_gov_aaaa" {
 
   alias {
     name                   = "d277n30llb5z4h.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -37,7 +37,7 @@ resource "aws_route53_record" "sbst_gov_www_sbst_gov_a" {
 
   alias {
     name                   = "d277n30llb5z4h.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -49,7 +49,7 @@ resource "aws_route53_record" "sbst_gov_www_sbst_gov_aaaa" {
 
   alias {
     name                   = "d277n30llb5z4h.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/search.gov.tf
+++ b/terraform/search.gov.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "search_gov_apex" {
 
   alias {
     name = "dcp2c9fh8vtdl.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -26,7 +26,7 @@ resource "aws_route53_record" "search_gov_www" {
 
   alias {
     name = "dv0x4a4ilr842.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/search.gov.tf
+++ b/terraform/search.gov.tf
@@ -1,0 +1,92 @@
+resource "aws_route53_zone" "search_toplevel" {
+  name = "search.gov"
+
+  tags {
+    Project = "dns"
+  }
+}
+
+resource "aws_route53_record" "search_gov_apex" {
+  zone_id = "${aws_route53_zone.search_toplevel.zone_id}"
+  name = "search.gov."
+  type = "A"
+
+  alias {
+    name = "dcp2c9fh8vtdl.cloudfront.net."
+    zone_id = "${local.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+# www.search.gov — redirects to search.gov through pages_redirect
+resource "aws_route53_record" "search_gov_www" {
+  zone_id = "${aws_route53_zone.search_toplevel.zone_id}"
+  name = "www.search.gov."
+  type = "A"
+
+  alias {
+    name = "dv0x4a4ilr842.cloudfront.net."
+    zone_id = "${local.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+# find.search.gov
+resource "aws_route53_record" "search_gov_find" {
+  zone_id = "${aws_route53_zone.search_toplevel.zone_id}"
+  name = "find.search.gov."
+  type = "A"
+
+  alias {
+    name = "proxy-east-lb-234082388.us-east-1.elb.amazonaws.com."
+    zone_id = "${local.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+# admin-center-downtime.search.gov
+resource "aws_route53_record" "search_gov_downtime" {
+  zone_id = "${aws_route53_zone.search_toplevel.zone_id}"
+  name = "admin-center-downtime.search.gov."
+  type = "A"
+  records = ["34.238.89.30"]
+  ttl     = "300"
+}
+
+# Email
+resource "aws_route53_record" "search_gov_mx" {
+  zone_id = "${aws_route53_zone.search_toplevel.zone_id}"
+  name = "search.gov."
+  type = "MX"
+  ttl = 300
+  records = ["10 inbound-smtp.us-east-1.amazonaws.com."]
+}
+
+resource "aws_route53_record" "search_gov__amazonses_search_gov_txt" {
+  zone_id = "${aws_route53_zone.search_toplevel.zone_id}"
+  name = "_amazonses.search.gov."
+  type = "TXT"
+  ttl = 300
+  records = ["bhZh0ZXP7e8vJ1zeTFVBUn/n1rE5NHWBzOIgVG71swI="]
+}
+
+# BOD
+resource "aws_route53_record" "search_gov_dmarc_search_gov_txt" {
+  zone_id = "${aws_route53_zone.search_toplevel.zone_id}"
+  name = "search.gov."
+  type = "TXT"
+  ttl = 300
+  records = ["v=spf1 include:amazonses.com include:mail.zendesk.com include:_spf.google.com -all"]
+}
+
+resource "aws_route53_record" "search_gov__dmarc_search_gov_txt" {
+  zone_id = "${aws_route53_zone.search_toplevel.zone_id}"
+  name = "_dmarc.search.gov."
+  type = "TXT"
+  ttl = 300
+  records = ["v=DMARC1; p=reject; pct=100; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov; fo=1; ri=86400"]
+}
+
+output "search_ns" {
+  value="${aws_route53_zone.search_toplevel.name_servers}"
+}

--- a/terraform/search.gov.tf
+++ b/terraform/search.gov.tf
@@ -35,13 +35,9 @@ resource "aws_route53_record" "search_gov_www" {
 resource "aws_route53_record" "search_gov_find" {
   zone_id = "${aws_route53_zone.search_toplevel.zone_id}"
   name = "find.search.gov."
-  type = "A"
-
-  alias {
-    name = "proxy-east-lb-234082388.us-east-1.elb.amazonaws.com."
-    zone_id = "${local.cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
+  type = "CNAME"
+  ttl = 5
+  records = ["search.usa.gov."]
 }
 
 # admin-center-downtime.search.gov

--- a/terraform/usa.gov.tf
+++ b/terraform/usa.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "usa_gov_analytics_usa_gov_a" {
   type    = "A"
   alias {
     name                   = "dkm80j4hktly2.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }
@@ -22,7 +22,7 @@ resource "aws_route53_record" "usa_gov_analytics_usa_gov_aaaa" {
   type    = "AAAA"
   alias {
     name                   = "dkm80j4hktly2.cloudfront.net."
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/terraform/usability.gov.tf
+++ b/terraform/usability.gov.tf
@@ -1,0 +1,88 @@
+# ------------------------------------------
+# WELCOME to the DNS records for Usability.gov
+# Before making edits, please reach out to #digitalgov (in TTS Slack) or email digitalgov@gsa.gov
+# ------------------------------------------
+
+
+resource "aws_route53_zone" "usability_toplevel" {
+  name = "usability.gov"
+  tags {
+    Project = "dns"
+  }
+}
+
+resource "aws_route53_record" "usability_gov_apex" {
+  zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
+  name    = "usability.gov."
+  type    = "A"
+
+  alias {
+    name                   = "XOXOXOXOXOXOXO.cloudfront.net."
+    zone_id                = "${local.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+# www.usability.gov — redirects to usability.gov through pages_redirect
+resource "aws_route53_record" "usability_gov_www" {
+  zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
+  name    = "www.usability.gov."
+  type    = "A"
+
+  alias {
+    name                   = "XOXOXOXOXOXOXO.cloudfront.net."
+    zone_id                = "${local.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+# demo.usability.gov
+resource "aws_route53_record" "demo_usability_gov_a" {
+  zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
+  name    = "demo.usability.gov."
+  type    = "A"
+
+  alias {
+    name                   = "XOXOXOXOXOXOXO.cloudfront.net."
+    zone_id                = "${local.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+
+# Compliance and ACME records -------------------------------
+
+# BOD / DMARC
+resource "aws_route53_record" "usability_gov__dmarc_usability_gov_txt" {
+  zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
+  name    = "_dmarc.usability.gov."
+  type    = "TXT"
+  ttl     = 300
+  records = ["${local.dmarc_reject}"]
+}
+
+
+# ACME Challenge records
+
+# usability.gov TXT / ACME Challenge
+resource "aws_route53_record" "usability_gov__acme-challenge_txt" {
+  zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
+  name    = "_acme-challenge.usability.gov."
+  type    = "TXT"
+  ttl     = 120
+  records = ["ABABABABABABAB"]
+}
+
+# demo.usability.gov TXT / ACME Challenge
+resource "aws_route53_record" "demo_usability_gov__acme-challenge_txt" {
+  zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
+  name    = "_acme-challenge.demo.usability.gov."
+  type    = "TXT"
+  ttl     = 120
+  records = ["ABABABABABABAB"]
+}
+
+
+output "usability_ns" {
+  value = "${aws_route53_zone.usability_toplevel.name_servers}"
+}

--- a/terraform/usability.gov.tf
+++ b/terraform/usability.gov.tf
@@ -17,7 +17,7 @@ resource "aws_route53_record" "usability_gov_apex" {
   type    = "A"
 
   alias {
-    name                   = "XOXOXOXOXOXOXO.cloudfront.net."
+    name                   = " d3882ehkypc0dh.cloudfront.net."
     zone_id                = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -30,7 +30,7 @@ resource "aws_route53_record" "usability_gov_www" {
   type    = "A"
 
   alias {
-    name                   = "XOXOXOXOXOXOXO.cloudfront.net."
+    name                   = " d3882ehkypc0dh.cloudfront.net."
     zone_id                = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -43,7 +43,7 @@ resource "aws_route53_record" "demo_usability_gov_a" {
   type    = "A"
 
   alias {
-    name                   = "XOXOXOXOXOXOXO.cloudfront.net."
+    name                   = " d3882ehkypc0dh.cloudfront.net."
     zone_id                = "${local.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -70,7 +70,7 @@ resource "aws_route53_record" "usability_gov__acme-challenge_txt" {
   name    = "_acme-challenge.usability.gov."
   type    = "TXT"
   ttl     = 120
-  records = ["ABABABABABABAB"]
+  records = ["9F_gDwJzeGpnWpbGphx1dLYa2GE9EYZuKCEH-qTck-8"]
 }
 
 # demo.usability.gov TXT / ACME Challenge
@@ -79,7 +79,7 @@ resource "aws_route53_record" "demo_usability_gov__acme-challenge_txt" {
   name    = "_acme-challenge.demo.usability.gov."
   type    = "TXT"
   ttl     = 120
-  records = ["ABABABABABABAB"]
+  records = ["9F_gDwJzeGpnWpbGphx1dLYa2GE9EYZuKCEH-qTck-8"]
 }
 
 

--- a/terraform/vote.gov.tf
+++ b/terraform/vote.gov.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "vote_gov_vote_gov_a" {
   type    = "A"
   alias {
     name                   = "d2s5gzwyabrtbd.cloudfront.net"
-    zone_id                = "${local.cloudfront_zone_id}"
+    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
     evaluate_target_health = false
   }
 }


### PR DESCRIPTION

This creates the initial record for getting Usability.gov set up in our DNS.
This is a template for @saracope can use when it is time to switch the domain over.

**See https://github.com/18F/dns/issues/420**

### Steps to take make the domain transfer
- [x]  Coordinate with the Federalist team and TTS Infra team on a day to launch
- [x]  Alert the HHS IT team of the day we plan on making the switch
- [x]  Ask the Federalist team for Cloudfront URLs (_needs to be done within 12hrs of the launch_)
- [ ] **Update the Cloudfront IDs** — Once you have the right Cloudfron IDs from the federalist team, insert them into the records everywhere you see `XOXOXOXOXOXOXO`
- [ ] **Update the ACME Challenge IDs** — Once you have the right ACME Challenge IDs from the federalist team, insert them into the records everywhere you see `ABABABABABABAB`
- [ ] **Redirect the `www`** — You'll have to figure out how you'll do the redirect, either through "Pages Redirect" with the Federalist team, or through the new paths in Route53 that @afeld setup.
- [ ]  Get the PR reviewed
- [ ]  Make the switch in DotGov
- [ ]  Merge the PR
- [ ]  Turn things on and off a few times till it works. 😆 
- [ ] [... unknown...]

Repo: https://github.com/GSA/digitalgov-usability
