### PR TITLE
ads.18f.gov and paid-leave-prototype.18f.gov prep to set to pages-redirects

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -85,16 +85,24 @@ resource "aws_route53_record" "18f_gov_accessibility_18f_gov_a" {
   }
 }
 
-# resource "aws_route53_record" "18f_gov_ads_18f_gov_a" {
-#   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-#   name = "ads.18f.gov."
-#   type = "A"
-#   alias {
-#     name = "d1p50apr0w92d2.cloudfront.net."
-#     zone_id = "${local.cloudfront_zone_id}"
-#     evaluate_target_health = false
-#   }
-# }
+resource "aws_route53_record" "18f_gov_ads_18f_gov_a" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "ads.18f.gov."
+  type = "A"
+  alias {
+    name = "d22116wmhcds2y.cloudfront.net."
+    zone_id = "${local.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "18f_gov__acme-challenge_ads_18f_gov_txt" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "_acme-challenge.ads.18f.gov."
+  type = "TXT"
+  ttl = 120
+  records = ["fXfES1KVPHxh87Y9iMVwl_ezEGRpKagAL7EzQpuYaBI"]
+}
 
 resource "aws_route53_record" "18f_gov_agile_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
@@ -739,24 +747,24 @@ resource "aws_route53_record" "18f_gov_pages_18f_gov_cname" {
   records = ["dvtze1xj8nrwl.cloudfront.net"]
 }
 
-# resource "aws_route53_record" "18f_gov_paid-leave-prototype_18f_gov_a" {
-#   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-#   name = "paid-leave-prototype.18f.gov."
-#   type = "A"
-#   alias {
-#     name = "d1tgknd7unaxw4.cloudfront.net."
-#     zone_id = "${local.cloudfront_zone_id}"
-#     evaluate_target_health = false
-#   }
-# }
+resource "aws_route53_record" "18f_gov_paid-leave-prototype_18f_gov_a" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "paid-leave-prototype.18f.gov."
+  type = "A"
+  alias {
+    name = "d3p6d6b3zaatqv.cloudfront.net."
+    zone_id = "${local.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
 
-# resource "aws_route53_record" "18f_gov__acme-challenge_paid_leave_prototype_18f_gov_txt" {
-#   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-#   name = "_acme-challenge.paid-leave-prototype.18f.gov."
-#   type = "TXT"
-#   ttl = 120
-#   records = ["PP01ymh2DTBj32M5vQLIIwwY0Nr6CVK12yu3oAnFcwg"]
-# }
+resource "aws_route53_record" "18f_gov__acme-challenge_paid_leave_prototype_18f_gov_txt" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name = "_acme-challenge.paid-leave-prototype.18f.gov."
+  type = "TXT"
+  ttl = 120
+  records = ["Rll4MS51zYr9CmfUEjs-0G5HExXnuQiyM_8MBjskIuw"]
+}
 
 resource "aws_route53_record" "18f_gov_partnership-playbook_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -85,16 +85,16 @@ resource "aws_route53_record" "18f_gov_accessibility_18f_gov_a" {
   }
 }
 
-resource "aws_route53_record" "18f_gov_ads_18f_gov_a" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "ads.18f.gov."
-  type = "A"
-  alias {
-    name = "d1p50apr0w92d2.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
-}
+# resource "aws_route53_record" "18f_gov_ads_18f_gov_a" {
+#   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+#   name = "ads.18f.gov."
+#   type = "A"
+#   alias {
+#     name = "d1p50apr0w92d2.cloudfront.net."
+#     zone_id = "${local.cloudfront_zone_id}"
+#     evaluate_target_health = false
+#   }
+# }
 
 resource "aws_route53_record" "18f_gov_agile_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
@@ -739,24 +739,24 @@ resource "aws_route53_record" "18f_gov_pages_18f_gov_cname" {
   records = ["dvtze1xj8nrwl.cloudfront.net"]
 }
 
-resource "aws_route53_record" "18f_gov_paid-leave-prototype_18f_gov_a" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "paid-leave-prototype.18f.gov."
-  type = "A"
-  alias {
-    name = "d1tgknd7unaxw4.cloudfront.net."
-    zone_id = "${local.cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
-}
+# resource "aws_route53_record" "18f_gov_paid-leave-prototype_18f_gov_a" {
+#   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+#   name = "paid-leave-prototype.18f.gov."
+#   type = "A"
+#   alias {
+#     name = "d1tgknd7unaxw4.cloudfront.net."
+#     zone_id = "${local.cloudfront_zone_id}"
+#     evaluate_target_health = false
+#   }
+# }
 
-resource "aws_route53_record" "18f_gov__acme-challenge_paid_leave_prototype_18f_gov_txt" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "_acme-challenge.paid-leave-prototype.18f.gov."
-  type = "TXT"
-  ttl = 120
-  records = ["PP01ymh2DTBj32M5vQLIIwwY0Nr6CVK12yu3oAnFcwg"]
-}
+# resource "aws_route53_record" "18f_gov__acme-challenge_paid_leave_prototype_18f_gov_txt" {
+#   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+#   name = "_acme-challenge.paid-leave-prototype.18f.gov."
+#   type = "TXT"
+#   ttl = 120
+#   records = ["PP01ymh2DTBj32M5vQLIIwwY0Nr6CVK12yu3oAnFcwg"]
+# }
 
 resource "aws_route53_record" "18f_gov_partnership-playbook_18f_gov_a" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"


### PR DESCRIPTION
PRs affecting a Federalist site must receive approval from a member of the relevant team.
