### PR TITLE
remove pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,0 @@
-PRs affecting a Federalist site must receive approval from a member of the relevant team.


### PR DESCRIPTION
Seems like it creates more confusion than it alleviates. We might want to look into [CODEOWNERS](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) to achieve what this was trying to, as a follow-up.