### PR TITLE
use wildcard SPF record for usability.gov

### DIFF
--- a/terraform/usability.gov.tf
+++ b/terraform/usability.gov.tf
@@ -42,13 +42,13 @@ resource "aws_route53_record" "usability_gov__spf" {
   records = ["${local.spf_no_mail}"]
 }
 
-# resource "aws_route53_record" "usability_gov__www_spf" {
-#   zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
-#   name = "www.usability.gov."
-#   type = "TXT"
-#   ttl = 300
-#   records = ["${local.spf_no_mail}"]
-# }
+resource "aws_route53_record" "usability_gov__wildcard_spf" {
+  zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
+  name = "*.usability.gov."
+  type = "TXT"
+  ttl = 300
+  records = ["${local.spf_no_mail}"]
+}
 
 # BOD / DMARC
 resource "aws_route53_record" "usability_gov__dmarc_usability_gov_txt" {

--- a/terraform/usability.gov.tf
+++ b/terraform/usability.gov.tf
@@ -11,6 +11,7 @@ resource "aws_route53_zone" "usability_toplevel" {
   }
 }
 
+# redirects to www.usability.gov through pages_redirect
 resource "aws_route53_record" "usability_gov_apex" {
   zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
   name = "usability.gov."
@@ -23,13 +24,15 @@ resource "aws_route53_record" "usability_gov_apex" {
   }
 }
 
-# www.usability.gov — redirects to usability.gov through pages_redirect
 resource "aws_route53_record" "usability_gov_www" {
   zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
   name = "www.usability.gov."
-  type = "CNAME"
-  ttl = 120
-  records = ["d3882ehkypc0dh.cloudfront.net."]
+  type = "A"
+  alias {
+    name = "d3882ehkypc0dh.cloudfront.net."
+    zone_id = "${local.cloud_gov_cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
 }
 
 # Compliance and ACME records -------------------------------


### PR DESCRIPTION
Follow-up to https://github.com/18F/dns/pull/440.

The goal here is to block mail from `www.usability.gov`. It was applied to `usability.gov` (no `www`) fine, but [the build failed](https://app.circleci.com/pipelines/github/18F/dns/56/workflows/33c2f2ee-b226-4535-b9c3-7d05eaf9b3c5/jobs/1093) because [you (apparently) can't have a TXT record on a CNAME](https://serverfault.com/a/834403). The DNS resolver will look to the destination server for TXT records, which in this case is CloudFront. CloudFront won't allow you to add DNS entries to the `.cloudfront.net` domains, so needed a different way.

Turns out that [the SPF spec allows wildcards](https://tools.ietf.org/html/rfc7208#section-3.5), which would allow blocking `www.usability.gov` and all other subdomains, which is what we really want. Unfortunately, [wildcards still don't apply to CNAMEs](https://www.cyber.gov.au/acsc/view-all-content/publications/how-combat-fake-emails#:~:text=Treatment%20of%20CNAME%20records), so that still wouldn't solve the problem for `www`.

Therefore, the last trick was to not use a CNAME. Route53 supports a special [alias](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html) setting that allows an `A` record to be used, which should also inherit the wildcard.

If this works, it will be a good pattern to apply to our other domains where we want to block all mail.