### PR TITLE
temporarily disable spf settings for www.usability.gov

### DIFF
--- a/terraform/usability.gov.tf
+++ b/terraform/usability.gov.tf
@@ -24,13 +24,13 @@ resource "aws_route53_record" "usability_gov_apex" {
 }
 
 # www.usability.gov — redirects to usability.gov through pages_redirect
-# resource "aws_route53_record" "usability_gov_www" {
-#   zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
-#   name = "www.usability.gov."
-#   type = "CNAME"
-#   ttl = 120
-#   records = ["d3882ehkypc0dh.cloudfront.net."]
-# }
+resource "aws_route53_record" "usability_gov_www" {
+  zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
+  name = "www.usability.gov."
+  type = "CNAME"
+  ttl = 120
+  records = ["d3882ehkypc0dh.cloudfront.net."]
+}
 
 # Compliance and ACME records -------------------------------
 
@@ -42,13 +42,13 @@ resource "aws_route53_record" "usability_gov__spf" {
   records = ["${local.spf_no_mail}"]
 }
 
-resource "aws_route53_record" "usability_gov__www_spf" {
-  zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
-  name = "www.usability.gov."
-  type = "TXT"
-  ttl = 300
-  records = ["${local.spf_no_mail}"]
-}
+# resource "aws_route53_record" "usability_gov__www_spf" {
+#   zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
+#   name = "www.usability.gov."
+#   type = "TXT"
+#   ttl = 300
+#   records = ["${local.spf_no_mail}"]
+# }
 
 # BOD / DMARC
 resource "aws_route53_record" "usability_gov__dmarc_usability_gov_txt" {

--- a/terraform/usability.gov.tf
+++ b/terraform/usability.gov.tf
@@ -24,13 +24,13 @@ resource "aws_route53_record" "usability_gov_apex" {
 }
 
 # www.usability.gov — redirects to usability.gov through pages_redirect
-resource "aws_route53_record" "usability_gov_www" {
-  zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
-  name = "www.usability.gov."
-  type = "CNAME"
-  ttl = 120
-  records = ["d3882ehkypc0dh.cloudfront.net."]
-}
+# resource "aws_route53_record" "usability_gov_www" {
+#   zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
+#   name = "www.usability.gov."
+#   type = "CNAME"
+#   ttl = 120
+#   records = ["d3882ehkypc0dh.cloudfront.net."]
+# }
 
 # Compliance and ACME records -------------------------------
 


### PR DESCRIPTION
@JJediny This entry is blocking any changes from being applied to route53 ... i have commnted it out until you can revise it


* aws_route53_record.usability_gov__www_spf: [ERR]: Error building changeset: InvalidChangeBatch: [RRSet of type TXT with DNS name www.usability.gov. is not permitted because a conflicting RRSet of type  CNAME with the same DNS name already exists in zone usability.gov.]
See circleci for more info