### PR TITLE
use module for managing email security records

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -24,20 +24,9 @@ resource "aws_route53_record" "18f_gov_github_18f_gov_txt" {
   records = ["606c521d44"]
 }
 
-resource "aws_route53_record" "18f_gov_18f_gov_txt" {
+module "18f_gov__email_security" {
+  source = "./email_security"
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "18f.gov."
-  type = "TXT"
-  ttl = 300
-  records = ["${local.spf_no_mail}"]
-}
-
-resource "aws_route53_record" "18f_gov__dmarc_18f_gov_txt" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name = "_dmarc.18f.gov."
-  type = "TXT"
-  ttl = 300
-  records = ["${local.dmarc_reject}"]
 }
 
 resource "aws_route53_record" "18f_gov__acme-challenge_18f_gov_txt" {

--- a/terraform/calc.gsa.gov.tf
+++ b/terraform/calc.gsa.gov.tf
@@ -34,12 +34,11 @@ resource "aws_route53_record" "calc_gsa_gov_ea1c6bc2bcfeca68fa3da9697e2b980d_cal
   records = ["88e8ce2c97c3ea10aa4ee2c7d26442a6141d7e53.comodoca.com."]
 }
 
-resource "aws_route53_record" "calc_gsa_gov_calc_gsa_gov_txt" {
+module "calc_gov__email_security" {
+  source = "./email_security"
+
   zone_id = "${aws_route53_zone.calc_gsa_gov_zone.zone_id}"
-  name    = "calc.gsa.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["v=spf1 include:amazonses.com ~all"]
+  txt_records = ["v=spf1 include:amazonses.com ~all"]
 }
 
 output "calc_gsa_gov_ns" {

--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -62,19 +62,9 @@ resource "aws_route53_record" "code_gov_api_cname" {
   records = ["api-code-gov.domains.api.data.gov"]
 }
 
-resource "aws_route53_record" "code_gov_code_gov_txt" {
+module "code_gov__email_security" {
+  source = "./email_security"
   zone_id = "${aws_route53_zone.code_toplevel.zone_id}"
-  name    = "code.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["${local.spf_no_mail}"]
-}
-resource "aws_route53_record" "code_gov__dmarc_code_gov_txt" {
-  zone_id = "${aws_route53_zone.code_toplevel.zone_id}"
-  name    = "_dmarc.code.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["${local.dmarc_reject}"]
 }
 
 output "code_ns" {

--- a/terraform/connect.gov.tf
+++ b/terraform/connect.gov.tf
@@ -40,18 +40,12 @@ resource "aws_route53_record" "connect_gov_connect_gov_mx" {
   records = ["1 aspmx.l.google.com", "5 alt2.aspmx.l.google.com", "5 alt1.aspmx.l.google.com", "10 alt3.aspmx.l.google.com", "10 alt4.aspmx.l.google.com"]
 }
 
-resource "aws_route53_record" "connect_gov_connect_gov_txt" {
-  zone_id = "${aws_route53_zone.connect_gov_zone.zone_id}"
-  name    = "connect.gov"
-  type    = "TXT"
-  ttl     = 1800
-  records = ["v=spf1 ~all", "google-site-verification=j3qyXzcDt_O3t0sdYy6FCQlYJnV5ASd0GYIhicPPzOg"]
-}
+module "connect_gov__email_security" {
+  source = "./email_security"
 
-resource "aws_route53_record" "connect_gov__dmarc_connect_gov_txt" {
   zone_id = "${aws_route53_zone.connect_gov_zone.zone_id}"
-  name    = "_dmarc.connect.gov"
-  ttl     = "900"
-  type    = "TXT"
-  records = ["${local.dmarc_reject}"]
+  txt_records = [
+    "v=spf1 ~all",
+    "google-site-verification=j3qyXzcDt_O3t0sdYy6FCQlYJnV5ASd0GYIhicPPzOg"
+  ]
 }

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -367,14 +367,11 @@ resource "aws_route53_record" "touchpoints_digital_gov_mx" {
 
 # Compliance and ACME records -------------------------------
 
-# BOD
+module "digital_gov__email_security" {
+  source = "./email_security"
 
-resource "aws_route53_record" "digital_gov_dmarc_digital_gov_txt" {
   zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
-  name    = "digital.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = [
+  txt_records = [
     "google-site-verification=Mi2rwVMxdp3eSbZughKvN0M_dwi6WLxMrRSsnLOWyVI",
     "${local.spf_hubspot}"
   ]
@@ -396,14 +393,6 @@ resource "aws_route53_record" "demo_pra_digital_gov__acme-challenge_txt" {
   type    = "TXT"
   ttl     = 120
   records = ["qzIXA_qU7a3io8b_FRxFVbPBUKZ83XtglufzS7qKnlg"]
-}
-
-resource "aws_route53_record" "digital_gov__dmarc_digital_gov_txt" {
-  zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
-  name    = "_dmarc.digital.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["${local.dmarc_reject}"]
 }
 
 # demo.touchpoints.digital.gov TXT / ACME Challenge

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -408,26 +408,15 @@ resource "aws_route53_record" "digitalgov_gov_dzc_digitalgov_gov_txt" {
 # =================================
 
 # BOD / SECURITY RECORDS (DMARC, SPF, etc...)
-# NOTE: the variables included these records `${local.spf_no_mail}` are set in https://github.com/18F/dns/blob/master/terraform/init.tf
 
+module "digitalgov_gov__email_security" {
+  source = "./email_security"
 
-resource "aws_route53_record" "digitalgov_gov_dmarc_digitalgov_gov_txt" {
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name    = "digitalgov.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = [
+  spf_records = [
     "google-site-verification=WRPUo6XC7m4X-8jJFvXPVs-W4uiqfEbF-pQYcD1-MOU",
     "${local.spf_hubspot}"
   ]
-}
-
-resource "aws_route53_record" "digitalgov_gov__dmarc_digitalgov_gov_txt" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name    = "_dmarc.digitalgov.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["${local.dmarc_reject}"]
 }
 
 # END BOD / SECURITY RECORDS (DMARC, SPF, etc...)

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -413,7 +413,7 @@ module "digitalgov_gov__email_security" {
   source = "./email_security"
 
   zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  spf_records = [
+  txt_records = [
     "google-site-verification=WRPUo6XC7m4X-8jJFvXPVs-W4uiqfEbF-pQYcD1-MOU",
     "${local.spf_hubspot}"
   ]

--- a/terraform/email_security/README.md
+++ b/terraform/email_security/README.md
@@ -1,0 +1,1 @@
+This module is meant to help implement Department of Homeland Security (DHS) [Binding Operational Directive (BOD) 18-01: _Enhance Email and Web Security_](https://cyber.dhs.gov/bod/18-01/). By default, the module assumes you do not send mail from the domain and will [have messages blocked](https://cyber.dhs.gov/bod/18-01/#what-should-be-done-with-domains-that-do-not-send-mail).

--- a/terraform/email_security/main.tf
+++ b/terraform/email_security/main.tf
@@ -4,12 +4,12 @@ data "aws_route53_zone" "zone" {
 
 # https://cyber.dhs.gov/bod/18-01/#what-should-be-done-with-domains-that-do-not-send-mail
 
-resource "aws_route53_record" "spf" {
+resource "aws_route53_record" "txt" {
   zone_id = "${var.zone_id}"
   name    = "${data.aws_route53_zone.zone.name}."
   type    = "TXT"
   ttl     = 300
-  records = ["${var.spf_records}"]
+  records = ["${var.txt_records}"]
 }
 
 resource "aws_route53_record" "dmarc" {

--- a/terraform/email_security/main.tf
+++ b/terraform/email_security/main.tf
@@ -2,8 +2,6 @@ data "aws_route53_zone" "zone" {
   zone_id = "${var.zone_id}"
 }
 
-# https://cyber.dhs.gov/bod/18-01/
-
 locals {
   # https://cyber.dhs.gov/bod/18-01/#dhs-dmarc-reporting-location
   dhs_dmarc_reporting_location = "mailto:reports@dmarc.cyber.dhs.gov"

--- a/terraform/email_security/main.tf
+++ b/terraform/email_security/main.tf
@@ -1,0 +1,23 @@
+data "aws_route53_zone" "zone" {
+  zone_id = "${var.zone_id}"
+}
+
+# https://cyber.dhs.gov/bod/18-01/#what-should-be-done-with-domains-that-do-not-send-mail
+
+resource "aws_route53_record" "spf" {
+  zone_id = "${var.zone_id}"
+  name    = "${data.aws_route53_zone.zone.name}."
+  type    = "TXT"
+  ttl     = 300
+  records = ["${var.spf_records}"]
+}
+
+resource "aws_route53_record" "dmarc" {
+  zone_id = "${var.zone_id}"
+  name    = "_dmarc.${data.aws_route53_zone.zone.name}."
+  type    = "TXT"
+  ttl     = 300
+
+  # https://cyber.dhs.gov/bod/18-01/#dhs-dmarc-reporting-location
+  records = ["v=DMARC1; p=${var.dmarc_policy}; pct=${var.dmarc_pct}; fo=1; ri=86400; rua=${var.dmarc_rua},mailto:reports@dmarc.cyber.dhs.gov; ruf=${var.dmarc_ruf}"]
+}

--- a/terraform/email_security/main.tf
+++ b/terraform/email_security/main.tf
@@ -2,7 +2,12 @@ data "aws_route53_zone" "zone" {
   zone_id = "${var.zone_id}"
 }
 
-# https://cyber.dhs.gov/bod/18-01/#what-should-be-done-with-domains-that-do-not-send-mail
+# https://cyber.dhs.gov/bod/18-01/
+
+locals {
+  # https://cyber.dhs.gov/bod/18-01/#dhs-dmarc-reporting-location
+  dhs_dmarc_reporting_location = "mailto:reports@dmarc.cyber.dhs.gov"
+}
 
 resource "aws_route53_record" "txt" {
   zone_id = "${var.zone_id}"
@@ -18,6 +23,5 @@ resource "aws_route53_record" "dmarc" {
   type    = "TXT"
   ttl     = 300
 
-  # https://cyber.dhs.gov/bod/18-01/#dhs-dmarc-reporting-location
-  records = ["v=DMARC1; p=${var.dmarc_policy}; pct=${var.dmarc_pct}; fo=1; ri=86400; rua=${var.dmarc_rua},mailto:reports@dmarc.cyber.dhs.gov; ruf=${var.dmarc_ruf}"]
+  records = ["v=DMARC1; p=${var.dmarc_policy}; pct=${var.dmarc_pct}; fo=1; ri=86400; rua=${var.dmarc_rua},${local.dhs_dmarc_reporting_location}; ruf=${var.dmarc_ruf}"]
 }

--- a/terraform/email_security/main.tf
+++ b/terraform/email_security/main.tf
@@ -9,7 +9,7 @@ locals {
 
 resource "aws_route53_record" "txt" {
   zone_id = "${var.zone_id}"
-  name    = "${data.aws_route53_zone.zone.name}."
+  name    = "${data.aws_route53_zone.zone.name}"
   type    = "TXT"
   ttl     = 300
   records = ["${var.txt_records}"]
@@ -17,7 +17,7 @@ resource "aws_route53_record" "txt" {
 
 resource "aws_route53_record" "dmarc" {
   zone_id = "${var.zone_id}"
-  name    = "_dmarc.${data.aws_route53_zone.zone.name}."
+  name    = "_dmarc.${data.aws_route53_zone.zone.name}"
   type    = "TXT"
   ttl     = 300
 

--- a/terraform/email_security/vars.tf
+++ b/terraform/email_security/vars.tf
@@ -17,7 +17,7 @@ variable "dmarc_ruf" {
   default = "mailto:dmarcfailures@gsa.gov"
 }
 
-variable "spf_records" {
+variable "txt_records" {
   default     = ["v=spf1 -all"]
   description = "Defaults to blocking all mail"
 }

--- a/terraform/email_security/vars.tf
+++ b/terraform/email_security/vars.tf
@@ -1,0 +1,27 @@
+variable "dmarc_pct" {
+  default     = 100
+  description = "https://cyber.dhs.gov/bod/18-01/#how-should-dmarc-be-deployed"
+}
+
+variable "dmarc_policy" {
+  default     = "reject"
+  description = "https://cyber.dhs.gov/bod/18-01/#how-should-dmarc-be-deployed"
+}
+
+variable "dmarc_rua" {
+  default     = "mailto:dmarcreports@gsa.gov"
+  description = "In addition to DHS"
+}
+
+variable "dmarc_ruf" {
+  default = "mailto:dmarcfailures@gsa.gov"
+}
+
+variable "spf_records" {
+  default     = ["v=spf1 -all"]
+  description = "Defaults to blocking all mail"
+}
+
+variable "zone_id" {
+  type = "string"
+}

--- a/terraform/email_security/vars.tf
+++ b/terraform/email_security/vars.tf
@@ -24,4 +24,5 @@ variable "txt_records" {
 
 variable "zone_id" {
   type = "string"
+  description = "Amazon Route 53 hosted zone ID. Records will be applied to the corresponding domain name."
 }

--- a/terraform/everykidinapark.gov.tf
+++ b/terraform/everykidinapark.gov.tf
@@ -45,20 +45,9 @@ resource "aws_route53_record" "everykidinapark_gov_398a1a6f10083c7a093fc5988ea19
   records = ["9bbc15d353b32d96be120d1cb2af1b89e0763167.comodoca.com."]
 }
 
-resource "aws_route53_record" "everykidinapark_gov_everykidinapark_gov_txt" {
+module "everykidinapark_gov__email_security" {
+  source = "./email_security"
   zone_id = "${aws_route53_zone.everykidinapark_gov_zone.zone_id}"
-  name    = "everykidinapark.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["${local.spf_no_mail}"]
-}
-
-resource "aws_route53_record" "everykidinapark_gov__dmarc_everykidinapark_gov_txt" {
-  zone_id = "${aws_route53_zone.everykidinapark_gov_zone.zone_id}"
-  name    = "_dmarc.everykidinapark.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["${local.dmarc_reject}"]
 }
 
 output "everykidinapark_gov_ns" {

--- a/terraform/findtreatment.gov.tf
+++ b/terraform/findtreatment.gov.tf
@@ -46,22 +46,12 @@ resource "aws_route53_record" "findtreatment_www_gov__acme-challenge_findtreatme
   records = ["D0rV3DqJMU-UoUnr2ijbLAWmVScbnnPCPCDj-_5B970"]
 }
 
-# BOD
-resource "aws_route53_record" "findtreatment_gov__dmarc_findtreatment_gov_txt" {
-  zone_id = "${aws_route53_zone.findtreatment_toplevel.zone_id}"
-  name    = "_dmarc.findtreatment.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["v=DMARC1; p=reject; pct=100; fo=1; ri=86400; rua=mailto:reports@dmarc.cyber.dhs.gov,mailto:hhs@rua.agari.com; ruf=mailto:hhs@ruf.agari.com"]
-}
+module "findtreatment_gov__email_security" {
+  source = "./email_security"
 
-# SPF
-resource "aws_route53_record" "findtreatment_gov__spf_findtreatment_gov_txt" {
   zone_id = "${aws_route53_zone.findtreatment_toplevel.zone_id}"
-  name    = "findtreatment.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["${local.spf_no_mail}"]
+  dmarc_rua = "mailto:hhs@rua.agari.com"
+  dmarc_ruf = "mailto:hhs@ruf.agari.com"
 }
 
 output "findtreatment_ns" {

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -14,10 +14,9 @@ locals {
   // https://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region
   elb_zone_id = "Z35SXDOTRQ7X7K"
 
-  dmarc_10     = "v=DMARC1; p=none; pct=10; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
-  dmarc_100    = "v=DMARC1; p=none; pct=100; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
+  # https://cyber.dhs.gov/bod/18-01/#how-should-dmarc-be-deployed
+  # https://cyber.dhs.gov/bod/18-01/#where-should-dmarc-reports-be-sent
   dmarc_reject = "v=DMARC1; p=reject; pct=100; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
 
-  spf_no_mail = "v=spf1 -all"
   spf_hubspot = "v=spf1 include:1962994.spf05.hubspotemail.net ~all"
 }

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -14,9 +14,6 @@ locals {
   // https://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region
   elb_zone_id = "Z35SXDOTRQ7X7K"
 
-  # https://cyber.dhs.gov/bod/18-01/#how-should-dmarc-be-deployed
-  # https://cyber.dhs.gov/bod/18-01/#where-should-dmarc-reports-be-sent
-  dmarc_reject = "v=DMARC1; p=reject; pct=100; fo=1; ri=86400; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov"
-
+  spf_no_mail = "v=spf1 -all"
   spf_hubspot = "v=spf1 include:1962994.spf05.hubspotemail.net ~all"
 }

--- a/terraform/innovation.gov.tf
+++ b/terraform/innovation.gov.tf
@@ -42,21 +42,9 @@ resource "aws_route53_record" "demo_innovation_gov_a" {
   }
 }
 
-# BOD
-resource "aws_route53_record" "innovation_gov_dmarc_innovation_gov_txt" {
+module "innovation_gov__email_security" {
+  source = "./email_security"
   zone_id = "${aws_route53_zone.innovation_toplevel.zone_id}"
-  name    = "innovation.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["${local.spf_no_mail}"]
-}
-
-resource "aws_route53_record" "innovation_gov__dmarc_innovation_gov_txt" {
-  zone_id = "${aws_route53_zone.innovation_toplevel.zone_id}"
-  name    = "_dmarc.innovation.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["${local.dmarc_reject}"]
 }
 
 output "innovation_ns" {

--- a/terraform/pif.gov.tf
+++ b/terraform/pif.gov.tf
@@ -26,12 +26,11 @@ resource "aws_route53_record" "mx" {
   records = ["10 alt3.aspmx.l.google.com.", "10 alt4.aspmx.l.google.com.", "1 aspmx.l.google.com.", "5 alt1.aspmx.l.google.com.", "5 alt2.aspmx.l.google.com."]
 }
 
-resource "aws_route53_record" "txt" {
+module "pif_gov__email_security" {
+  source = "./email_security"
+
   zone_id = "${aws_route53_zone.pif_toplevel.zone_id}"
-  name    = "pif.gov."
-  type    = "TXT"
-  ttl     = 60
-  records = ["v=spf1 include:gsa.gov ~all"]
+  txt_records = ["v=spf1 include:gsa.gov ~all"]
 }
 
 resource "aws_route53_record" "pif_gov_domainkey_pif_gov_txt" {
@@ -42,14 +41,6 @@ resource "aws_route53_record" "pif_gov_domainkey_pif_gov_txt" {
   records = [
     "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsaAjhxSW+z1C0s3e+t1ieRB0VrUGKHMTcENFdoVs6hnUMgMNXpX3EGo61TXHRBghX6bP1aoNN8TjouUB1/HNUqA7i0gCEQwN12O67+gKl5qy6poLroTs9pBVsKr\"\"iDHbCR0y9hzE8zuboOVerR+J7cnpwvm/GhNf3TBDU8MojtwM4DEzHYrpe/qMNYAnQp7G5kfTpqq2pyZMzu+O7c1/E8WF/PjEyeAm1dtqnLeCmCcXP3Z3YMRe5VC8++GPdUsnxxggDgh8WQ6TBKWMLx0FZbKswIphIo/Xq3CNsscqhC7rTUljiZzbEKEs17NRPjO70p44k5q1lJE686f4eZ9X6pwIDAQAB"
   ]
-}
-
-resource "aws_route53_record" "pif_gov__dmarc_pif_gov_txt" {
-  zone_id = "${aws_route53_zone.pif_toplevel.zone_id}"
-  name    = "_dmarc.pif.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["${local.dmarc_reject}"]
 }
 
 resource "aws_route53_record" "paygap_slack_cname" {

--- a/terraform/plainlanguage.gov.tf
+++ b/terraform/plainlanguage.gov.tf
@@ -61,26 +61,15 @@ resource "aws_route53_record" "plainlanguage_google_mx" {
   ]
 }
 
-resource "aws_route53_record" "plainlanguage_google_txt" {
+module "plainlanguage_gov__email_security" {
+  source = "./email_security"
+
   zone_id = "${aws_route53_zone.plainlanguage_toplevel.zone_id}"
-  name    = "plainlanguage.gov."
-  type    = "TXT"
-  ttl     = 600
-  records = [
+  txt_records = [
     "google-site-verification=dgYaMRA2hd9PDUV1zEcRyWmTOVZCbkbP3vXd4isEZLI",
     "v=spf1 include:_spf.google.com include:spf_sa.gsa.gov ~all"
   ]
 }
-
-# BOD
-resource "aws_route53_record" "plainlanguage_gov__dmarc_plainlanguage_gov_txt" {
-  zone_id = "${aws_route53_zone.plainlanguage_toplevel.zone_id}"
-  name    = "_dmarc.plainlanguage.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["${local.dmarc_reject}"]
-}
-
 
 output "plainlanguage_ns" {
   value = "${aws_route53_zone.plainlanguage_toplevel.name_servers}"

--- a/terraform/presidentialinnovationfellows.gov.tf
+++ b/terraform/presidentialinnovationfellows.gov.tf
@@ -40,7 +40,12 @@ resource "aws_route53_record" "presidentialinnovationfellows_mx" {
 
 module "presidentialinnovationfellows_gov__email_security" {
   source = "./email_security"
+
   zone_id = "${aws_route53_zone.presidentialinnovationfellows_toplevel.zone_id}"
+  txt_records = [
+    "${local.spf_no_mail}",
+    "google-site-verification=RBhAMKMQvrHWfxNfosQ9oUrrcwAme78JlrhD3cTQCvY"
+  ]
 }
 
 resource "aws_route53_record" "presidentialinnovationfellows_gov__github-challenge-presidential-innovation-fellows_presidentialinnovationfellows_gov_txt" {

--- a/terraform/presidentialinnovationfellows.gov.tf
+++ b/terraform/presidentialinnovationfellows.gov.tf
@@ -38,21 +38,9 @@ resource "aws_route53_record" "presidentialinnovationfellows_mx" {
   records = ["10 alt3.aspmx.l.google.com.", "10 alt4.aspmx.l.google.com.", "1 aspmx.l.google.com.", "5 alt1.aspmx.l.google.com.", "5 alt2.aspmx.l.google.com."]
 }
 
-resource "aws_route53_record" "presidentialinnovationfellows_apex_txt" {
+module "presidentialinnovationfellows_gov__email_security" {
+  source = "./email_security"
   zone_id = "${aws_route53_zone.presidentialinnovationfellows_toplevel.zone_id}"
-  name    = "presidentialinnovationfellows.gov."
-  type    = "TXT"
-  ttl     = 60
-  records = ["${local.spf_no_mail}",
-  "google-site-verification=RBhAMKMQvrHWfxNfosQ9oUrrcwAme78JlrhD3cTQCvY"]
-}
-
-resource "aws_route53_record" "presidentialinnovationfellows__dmarc_presidentialinnovationfellows_txt" {
-  zone_id = "${aws_route53_zone.presidentialinnovationfellows_toplevel.zone_id}"
-  name    = "_dmarc.presidentialinnovationfellows.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["${local.dmarc_reject}"]
 }
 
 resource "aws_route53_record" "presidentialinnovationfellows_gov__github-challenge-presidential-innovation-fellows_presidentialinnovationfellows_gov_txt" {

--- a/terraform/sbst.gov.tf
+++ b/terraform/sbst.gov.tf
@@ -62,20 +62,9 @@ resource "aws_route53_record" "sbst_gov_6020162f64c7bb016b2a3de7428839d0_www_sbs
   records = ["e1eaa443027a9960e21419ecde173b2b8ebdf10b.comodoca.com."]
 }
 
-resource "aws_route53_record" "sbst_gov__dmarc_sbst_gov_txt" {
+module "sbst_gov__email_security" {
+  source = "./email_security"
   zone_id = "${aws_route53_zone.sbst_gov_zone.zone_id}"
-  name    = "_dmarc.sbst.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["${local.dmarc_reject}"]
-}
-
-resource "aws_route53_record" "sbst_gov_sbst_gov_txt" {
-  zone_id = "${aws_route53_zone.sbst_gov_zone.zone_id}"
-  name    = "sbst.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["v=spf1 -all"]
 }
 
 output "sbst_gov_ns" {

--- a/terraform/search.gov.tf
+++ b/terraform/search.gov.tf
@@ -66,21 +66,11 @@ resource "aws_route53_record" "search_gov__amazonses_search_gov_txt" {
   records = ["bhZh0ZXP7e8vJ1zeTFVBUn/n1rE5NHWBzOIgVG71swI="]
 }
 
-# BOD
-resource "aws_route53_record" "search_gov_dmarc_search_gov_txt" {
-  zone_id = "${aws_route53_zone.search_toplevel.zone_id}"
-  name = "search.gov."
-  type = "TXT"
-  ttl = 300
-  records = ["v=spf1 include:amazonses.com include:mail.zendesk.com include:_spf.google.com -all"]
-}
+module "search_gov__email_security" {
+  source = "./email_security"
 
-resource "aws_route53_record" "search_gov__dmarc_search_gov_txt" {
   zone_id = "${aws_route53_zone.search_toplevel.zone_id}"
-  name = "_dmarc.search.gov."
-  type = "TXT"
-  ttl = 300
-  records = ["v=DMARC1; p=reject; pct=100; rua=mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:dmarcfailures@gsa.gov; fo=1; ri=86400"]
+  txt_records = ["v=spf1 include:amazonses.com include:mail.zendesk.com include:_spf.google.com -all"]
 }
 
 output "search_ns" {

--- a/terraform/usability.gov.tf
+++ b/terraform/usability.gov.tf
@@ -34,23 +34,10 @@ resource "aws_route53_record" "usability_gov_www" {
 
 # Compliance and ACME records -------------------------------
 
-resource "aws_route53_record" "usability_gov__spf" {
+module "usability_gov__email_security" {
+  source = "./email_security"
   zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
-  name = "usability.gov."
-  type = "TXT"
-  ttl = 300
-  records = ["${local.spf_no_mail}"]
 }
-
-# BOD / DMARC
-resource "aws_route53_record" "usability_gov__dmarc_usability_gov_txt" {
-  zone_id = "${aws_route53_zone.usability_toplevel.zone_id}"
-  name = "_dmarc.usability.gov."
-  type = "TXT"
-  ttl = 300
-  records = ["${local.dmarc_reject}"]
-}
-
 
 # ACME Challenge records
 

--- a/terraform/vote.gov.tf
+++ b/terraform/vote.gov.tf
@@ -21,7 +21,7 @@ resource "aws_route53_record" "vote_gov_vote_gov_txt" {
   name    = "vote.gov."
   type    = "TXT"
   ttl     = 300
-  records = ["${local.spf_no_mail}", "blitz=mu-cbb11232-c5e05a4b-b13f3a3c-060b48f0"]
+  records = ["blitz=mu-cbb11232-c5e05a4b-b13f3a3c-060b48f0"]
 }
 
 resource "aws_route53_record" "vote_gov_01872332dafeeb93b927e2d9e9b2c53d_vote_gov_cname" {
@@ -75,13 +75,9 @@ resource "aws_route53_record" "staging_vote_gov_txt" {
   records = ["-IQdOpZZcQmMfAedslZpwYCbAsFPC92MLVyVzh53uqc"]
 }
 
-# BOD / DMARC
-resource "aws_route53_record" "vote_gov__dmarc_vote_gov_txt" {
+module "vote_gov__email_security" {
+  source = "./email_security"
   zone_id = "${aws_route53_zone.vote_gov_zone.zone_id}"
-  name    = "_dmarc.vote.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["${local.dmarc_reject}"]
 }
 
 output "vote_gov_ns" {

--- a/terraform/vote.gov.tf
+++ b/terraform/vote.gov.tf
@@ -16,14 +16,6 @@ resource "aws_route53_record" "vote_gov_vote_gov_a" {
   }
 }
 
-resource "aws_route53_record" "vote_gov_vote_gov_txt" {
-  zone_id = "${aws_route53_zone.vote_gov_zone.zone_id}"
-  name    = "vote.gov."
-  type    = "TXT"
-  ttl     = 300
-  records = ["blitz=mu-cbb11232-c5e05a4b-b13f3a3c-060b48f0"]
-}
-
 resource "aws_route53_record" "vote_gov_01872332dafeeb93b927e2d9e9b2c53d_vote_gov_cname" {
   zone_id = "${aws_route53_zone.vote_gov_zone.zone_id}"
   name    = "01872332dafeeb93b927e2d9e9b2c53d.vote.gov."
@@ -77,7 +69,12 @@ resource "aws_route53_record" "staging_vote_gov_txt" {
 
 module "vote_gov__email_security" {
   source = "./email_security"
+
   zone_id = "${aws_route53_zone.vote_gov_zone.zone_id}"
+  txt_records = [
+    "${local.spf_no_mail}",
+    "blitz=mu-cbb11232-c5e05a4b-b13f3a3c-060b48f0"
+  ]
 }
 
 output "vote_gov_ns" {


### PR DESCRIPTION
As part of https://github.com/18F/tts-tech-portfolio/issues/572, I started inspecting and tweaking our various SPF and DMARC records. This led me down a rabbit hole, and before I knew it I had refactored how they are specified across the board.

This pull request creates an `email_security` [module](https://www.terraform.io/docs/configuration/modules.html), which is then used everywhere there were SPF/DMARC records before. This ensures our email security is consistent across the board, and it's a bit clearer what actually needs to be specified and what the different values mean.

Moving those records from the top-level into a module means a bunch of records will be deleted and re-created, so it's hard to tell what the net change is. Therefore, I'd like to:

1. [x] Get a 👍 on the overall approach in the draft pull request
1. [x] Do a bunch of [`terraform state mv`](https://www.terraform.io/docs/commands/state/mv.html)s so that the `terraform plan` shows the net differences. (There should be few.)
1. [x] Do another `terraform plan` to see the differences
1. [x] Fix any typos or TXT records I may have missed
1. [ ] Merge
1. [ ] Get another scan to be done

Would love to hear thoughts!