### PR TITLE
add tests for SPF and DMARC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,18 @@ jobs:
           name: Deploy the full environment
           command: terraform apply -input=false -auto-approve terraform
 
+  validate:
+    docker:
+      - image: python:3-alpine
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: pip install -r requirements.txt
+      - run:
+          name: Run validations
+          command: pytest tests
+
 workflows:
   version: 2
 
@@ -53,6 +65,12 @@ workflows:
               only: master
           requires:
             - plan
+      - validate:
+          filters:
+            branches:
+              only: master
+          requires:
+            - apply
 
 experimental:
   notify:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 credentials.yml
 .terraform/
 *.tfstate*
+__pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+boto3~=1.14.5
+checkdmarc~=4.2.4
+pytest~=5.4.3

--- a/tests/test_email_security.py
+++ b/tests/test_email_security.py
@@ -1,11 +1,11 @@
 import boto3
 import checkdmarc
 import pytest
-import re
 
 
 def is_second_level_domain(zone_name):
-    return len(re.findall(r"\.", zone_name)) == 2
+    levels = zone_name.rstrip(".").split(".")
+    return len(levels) == 2
 
 
 def second_level_domains():
@@ -20,6 +20,7 @@ def second_level_domains():
 
 
 def test_is_second_level_domain():
+    assert is_second_level_domain("foo.bar")
     assert is_second_level_domain("foo.bar.")
     assert not is_second_level_domain("foo.bar.baz.")
 

--- a/tests/test_email_security.py
+++ b/tests/test_email_security.py
@@ -1,0 +1,9 @@
+import checkdmarc
+import pytest
+
+
+@pytest.mark.parametrize("domain", ["afeld.me", "usability.gov"])
+def test_has_email_security_records(domain):
+    result = checkdmarc.check_domains([domain])
+    assert result["spf"]["valid"]
+    assert result["dmarc"]["valid"]

--- a/tests/test_email_security.py
+++ b/tests/test_email_security.py
@@ -1,9 +1,26 @@
+import boto3
 import checkdmarc
 import pytest
 
 
-@pytest.mark.parametrize("domain", ["afeld.me", "usability.gov"])
+def second_level_domain(zone_name):
+    parts = zone_name.rstrip(".").split(".")[-2:]
+    return ".".join(parts)
+
+
+def second_level_domains():
+    route53 = boto3.client("route53")
+    response = route53.list_hosted_zones()
+    return set(second_level_domain(zone["Name"]) for zone in response["HostedZones"])
+
+
+def test_second_level_domain():
+    assert second_level_domain("foo.bar.baz.") == "bar.baz"
+    assert second_level_domain("foo.bar.") == "foo.bar"
+
+
+@pytest.mark.parametrize("domain", second_level_domains())
 def test_has_email_security_records(domain):
     result = checkdmarc.check_domains([domain])
-    assert result["spf"]["valid"]
-    assert result["dmarc"]["valid"]
+    assert result["spf"]["valid"], f"{domain} has missing/invalid SPF record"
+    assert result["dmarc"]["valid"], f"{domain} has missing/invalid DMARC record"


### PR DESCRIPTION
Ensures that all second-level domains have valid records. Part of https://github.com/18F/tts-tech-portfolio/issues/572.