### PR TITLE
Findtreatment.gov - Add TXT record for entrust ssl cert challenge

### DIFF
--- a/terraform/findtreatment.gov.tf
+++ b/terraform/findtreatment.gov.tf
@@ -54,6 +54,14 @@ module "findtreatment_gov__email_security" {
   dmarc_ruf = "mailto:hhs@ruf.agari.com"
 }
 
+resource "aws_route53_record" "findtreatment_gov__entrust-challenge_findtreatment_gov_txt" {
+  zone_id = "${aws_route53_zone.findtreatment_toplevel.zone_id}"
+  name    = "_pki-validation.FINDTREATMENT.GOV."
+  type    = "TXT"
+  ttl     = 120
+  records = ["4078-0BF0-FEEC-0B21-AA16-6F89-3758-4EBB"]
+}
+
 output "findtreatment_ns" {
   value = "${aws_route53_zone.findtreatment_toplevel.name_servers}"
 }


### PR DESCRIPTION
Adds a TXT record to satisfy the SSL cert challenge. Once HHS has installed the cert, they will be moving DNS from GSA to HHS, ETA Monday or Tuesday.