### PR TITLE
Redirect workflow.digital.gov to digital.gov/workflow

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -63,6 +63,19 @@ resource "aws_route53_record" "workflow_digital_gov_a" {
   }
 }
 
+# workflow.digitalgov.gov
+# redirects to digital.gov/workflow
+module "digital_gov__workflow_digital_gov_redirect" {
+  source = "mediapop/redirect/aws"
+  version = "1.2.1"
+
+  domains = {
+    "digital.gov." = ["workflow.digital.gov"]
+  }
+
+  redirect_to = "https://digital.gov/workflow"
+}
+
 # USWDS - U.S. Web Design System -------------------------------
 # designsystem.digital.gov — A
 # (Master site in Federalist)

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -60,7 +60,7 @@ module "digital_gov__workflow_digital_gov_redirect" {
     "digital.gov." = ["workflow.digital.gov"]
   }
 
-  redirect_to = "https://digital.gov/workflow"
+  redirect_to = "https://digital.gov/workflow/"
 }
 
 # USWDS - U.S. Web Design System -------------------------------


### PR DESCRIPTION
Based on the guidance in https://github.com/18F/dns/pull/410/, this redirects `workflow.digital.gov` to `digital.gov/workflow`.