### PR TITLE
workflow.digital.gov no longer point to site

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -50,19 +50,6 @@ resource "aws_route53_record" "demo_digital_gov_a" {
   }
 }
 
-# workflow.digital.gov
-resource "aws_route53_record" "workflow_digital_gov_a" {
-  zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
-  name    = "workflow.digital.gov."
-  type    = "A"
-
-  alias {
-    name                   = "d1m1gatn2ksd43.cloudfront.net."
-    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
-}
-
 # workflow.digitalgov.gov
 # redirects to digital.gov/workflow
 module "digital_gov__workflow_digital_gov_redirect" {


### PR DESCRIPTION
remove workflow.digital.gov that points to cloudfront distro