### PR TITLE
Redirect emerging.digital.gov

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -160,16 +160,17 @@ resource "aws_route53_record" "public_sans_digital_gov_a" {
 
 
 # Digital.gov Guides -------------------------------
-# emerging.digital.gov — A -------------------------------
-resource "aws_route53_record" "emerging_digital_gov_a" {
-  zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
-  name    = "emerging.digital.gov."
-  type    = "A"
-  alias {
-    name                   = "d2b40qcr6kbxp7.cloudfront.net."
-    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
-    evaluate_target_health = false
+# emerging.digital.gov
+# redirects to https://digital.gov/topics/emerging-tech/
+module "digital_gov__emerging_digital_gov_redirect" {
+  source = "mediapop/redirect/aws"
+  version = "1.2.1"
+
+  domains = {
+    "digital.gov." = ["emerging.digital.gov"]
   }
+
+  redirect_to = "https://digital.gov/topics/emerging-tech"
 }
 
 # accessibility.digital.gov — A -------------------------------


### PR DESCRIPTION
Redirect https://emerging.digital.gov/ to https://digital.gov/topics/emerging-tech/