### PR TITLE
Remove www.plainlanguage.gov

### DIFF
--- a/terraform/plainlanguage.gov.tf
+++ b/terraform/plainlanguage.gov.tf
@@ -23,18 +23,6 @@ resource "aws_route53_record" "plainlanguage_apex" {
   }
 }
 
-resource "aws_route53_record" "plainlanguage_www" {
-  zone_id = "${aws_route53_zone.plainlanguage_toplevel.zone_id}"
-  name    = "www.plainlanguage.gov."
-  type    = "A"
-
-  alias {
-    name                   = "${local.plainlanguage_cloudfront}"
-    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
-}
-
 resource "aws_route53_record" "demo_plainlanguage_a" {
   zone_id = "${aws_route53_zone.plainlanguage_toplevel.zone_id}"
   name    = "demo.plainlanguage.gov."

--- a/terraform/plainlanguage.gov.tf
+++ b/terraform/plainlanguage.gov.tf
@@ -10,10 +10,9 @@ locals {
   plainlanguage_cloudfront = "d1qy5q7pncs690.cloudfront.net."
 }
 
-
-resource "aws_route53_record" "plainlanguage_apex" {
+resource "aws_route53_record" "plainlanguage_www" {
   zone_id = "${aws_route53_zone.plainlanguage_toplevel.zone_id}"
-  name    = "plainlanguage.gov."
+  name    = "www.plainlanguage.gov."
   type    = "A"
 
   alias {


### PR DESCRIPTION
Issue:
plainlanguage.gov is getting dinged for HSTS error `Needs includeSubDomains`
https://hstspreload.org/?domain=plainlanguage.gov

Suggested fix:
from @amirbey: looking at 18f/dns it appears that you have both plainlanguge.gov and www.plainlanguage.gov pointing to your Federalist site. the convention is to have only 1 domain (ie: www.plainlanguage.gov) point to your Federalist site and setup a redirect from plainlanguage.gov to www.plainlanguage.gov using pages-redirects. if you do this then you can set your HSTS header appropriately in your pages-redirects redirect

Changes:
In this PR, remove `www.plainlanguage.gov` from `plainlanguage.gov.tf`
In a related PR on 18F/page-redirect, update www.plainlanguage.gov to redirect to plainlanguage.gov
https://github.com/18F/pages-redirects/pull/167