### PR TITLE
temp remove (www.)plainlanguage.gov to setup redirect

### DIFF
--- a/terraform/plainlanguage.gov.tf
+++ b/terraform/plainlanguage.gov.tf
@@ -6,35 +6,6 @@ resource "aws_route53_zone" "plainlanguage_toplevel" {
   }
 }
 
-locals {
-  plainlanguage_cloudfront = "d1qy5q7pncs690.cloudfront.net."
-}
-
-
-resource "aws_route53_record" "plainlanguage_apex" {
-  zone_id = "${aws_route53_zone.plainlanguage_toplevel.zone_id}"
-  name    = "plainlanguage.gov."
-  type    = "A"
-
-  alias {
-    name                   = "${local.plainlanguage_cloudfront}"
-    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "plainlanguage_www" {
-  zone_id = "${aws_route53_zone.plainlanguage_toplevel.zone_id}"
-  name    = "www.plainlanguage.gov."
-  type    = "A"
-
-  alias {
-    name                   = "${local.plainlanguage_cloudfront}"
-    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
-}
-
 resource "aws_route53_record" "demo_plainlanguage_a" {
   zone_id = "${aws_route53_zone.plainlanguage_toplevel.zone_id}"
   name    = "demo.plainlanguage.gov."


### PR DESCRIPTION
<!-- Is this a new public-facing site? If so, please provide some context and assign to @18F/osc for review. -->
remove domains to create 2 CDNs using external-domain service for pages-redirects to apply HSTS headers
- plainlanguage.gov
- www.plainlanguage.gov
