### PR TITLE
remove cloud_gov_external_domain_zone_id env var usage

### DIFF
--- a/terraform/cloud.gov.tf
+++ b/terraform/cloud.gov.tf
@@ -1,12 +1,6 @@
 # cloud.gov DNS configuration is managed separately:
 # https://github.com/18F/cg-provision/blob/master/terraform/stacks/dns/stack.tf
 
-variable "cloud_gov_external_domain_zone_id" {
-  type        = "string"
-  description = "zone for cloud.gov external domains"
-}
-
 locals {
   cloud_gov_cloudfront_zone_id      = "Z2FDTNDATAQYW2"
-  cloud_gov_external_domain_zone_id = "${var.cloud_gov_external_domain_zone_id}"
 }


### PR DESCRIPTION
<!-- Is this a new public-facing site? If so, please provide some context and assign to @18F/osc for review. -->
