### PR TITLE
remove climate-data-user-study.18f.gov to re-add to https://github.com/18F/climate-labs

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -321,18 +321,6 @@ resource "aws_route53_record" "18f_gov_chat_18f_gov_a" {
   records = ["d2yc8l40kkdvr0.cloudfront.net"]
 }
 
-resource "aws_route53_record" "18f_gov_climate-data-user-study_18f_gov_a" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name    = "climate-data-user-study.18f.gov."
-  type    = "A"
-
-  alias {
-    name                   = "d28r76t17zvn4f.cloudfront.net."
-    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
-}
-
 resource "aws_route53_record" "18f_gov_compliance-viewer_18f_gov_cname" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name    = "compliance-viewer.18f.gov."


### PR DESCRIPTION
remove to prep for redirect app

<!-- Is this a new public-facing site? If so, please provide some context and assign to @18F/osc for review. -->
