### PR TITLE
set dns for climate-data-user-study.18f.gov to point to external-domain service

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -1185,6 +1185,24 @@ resource "aws_route53_record" "18f_gov__acme_challenge_federalist_test_site_18f_
   records = ["_acme-challenge.federalist-test-site.18f.gov.external-domains-production.cloud.gov."]
 }
 
+# climate-data-user-study.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "18f_gov_climate_data_user_study_18f_gov_cname" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name    = "climate-data-user-study.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["climate-data-user-study.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# climate-data-user-study.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "18f_gov__acme_challenge_climate_data_user_study_18f_gov_cname" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name    = "_acme-challenge.climate-data-user-study.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.climate-data-user-study.18f.gov.external-domains-production.cloud.gov."]
+}
+
 output "18f_gov_ns" {
   value = "${aws_route53_zone.18f_gov_zone.name_servers}"
 }


### PR DESCRIPTION
https://github.com/18F/tts-tech-portfolio/issues/1026

<!-- Is this a new public-facing site? If so, please provide some context and assign to @18F/osc for review. -->
