### PR TITLE
remove  demo.digital.gov - no longer used

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -37,19 +37,6 @@ resource "aws_route53_record" "digital_gov_www" {
   }
 }
 
-# demo.digital.gov
-resource "aws_route53_record" "demo_digital_gov_a" {
-  zone_id = "${aws_route53_zone.digital_toplevel.zone_id}"
-  name    = "demo.digital.gov."
-  type    = "A"
-
-  alias {
-    name                   = "d1f2igtqmwwbgm.cloudfront.net."
-    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
-}
-
 # workflow.digitalgov.gov
 # redirects to digital.gov/workflow
 module "digital_gov__workflow_digital_gov_redirect" {


### PR DESCRIPTION
<!-- Is this a new public-facing site? If so, please provide some context and assign to @18F/osc for review. -->
