### PR TITLE
Update 18f.gov.tf with google site verification

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -28,7 +28,11 @@ resource "aws_route53_record" "18f_gov_github_18f_gov_txt" {
 
 module "18f_gov__email_security" {
   source  = "./email_security"
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}",
+  txt_records = [
+    "${local.spf_no_mail}",
+    "google-site-verification=HwR6BJFZpjma0wYRYRejCxvOSDuE_tycmgV2_h6y_TA"
+  ]
 }
 
 resource "aws_route53_record" "18f_gov__acme-challenge_18f_gov_txt" {


### PR DESCRIPTION
Add a text record for 18f.gov to verify domain ownership to google site verification so we can gather google search data across our microsites on the 18f.gov domain and send that data to Google Analytics. Additional background to the ask in #analytics --  https://gsa-tts.slack.com/archives/C02AK9NKP/p1609169774064500
This edit is based on similar edit in https://github.com/18F/dns/commit/fa79e80f56d4b715a02e754d00c9a8860b41cbe7

<!-- Is this a new public-facing site? If so, please provide some context and assign to @18F/osc for review. -->
