### PR TITLE
update demo.digitalgov.gov cname cloudfront url

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -61,7 +61,7 @@ resource "aws_route53_record" "demo_digitalgov_gov_a" {
   type    = "CNAME"
   ttl     = "300"
   records = [
-    "d1wh5biaq5z7yu.cloudfront.net."
+    "d28nvabzyjalfm.cloudfront.net."
   ]
 }
 


### PR DESCRIPTION
demo.digitalgov.gov is pointing to wrong cdn

<!-- Is this a new public-facing site? If so, please provide some context and assign to @18F/osc for review. -->
