### PR TITLE
remove demo.digitalgov.gov

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -54,17 +54,6 @@ resource "aws_route53_record" "digitalgov_gov_www" {
   ]
 }
 
-# demo.digitalgov.gov — redirects to demo.digital.gov through pages_redirect
-resource "aws_route53_record" "demo_digitalgov_gov_a" {
-  zone_id = "${aws_route53_zone.digitalgov_gov_zone.zone_id}"
-  name    = "demo.digitalgov.gov."
-  type    = "CNAME"
-  ttl     = "300"
-  records = [
-    "d28nvabzyjalfm.cloudfront.net."
-  ]
-}
-
 # OpenOpps
 # openopps.digitalgov.gov — redirects to openopps.usajobs.gov through pages_redirect
 resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_a" {


### PR DESCRIPTION
demo.digitalgov.gov was intended to(but appears to not have for quite some time if ever) redirect to digital.gov which no longer existed
https://github.com/18F/pages-redirects/blob/3d40f070444f3dc7d383b3b860257db7df003426/templates/_federalist-redirects.njk#L85
https://github.com/18F/dns/pull/502#pullrequestreview-552481655

<!-- Is this a new public-facing site? If so, please provide some context and assign to @18F/osc for review. -->
