### PR TITLE
Update DNS for govconnect.18f.gov to point to new cg external domain …

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -529,16 +529,22 @@ resource "aws_route53_record" "18f_gov_fugacious_18f_gov_txt" {
   records = ["d309sw0ah4sgku.cloudfront.net."]
 }
 
-resource "aws_route53_record" "18f_gov_govconnect_18f_gov_a" {
+# govconnect.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "18f_gov_govconnect_18f_gov_cname" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
   name    = "govconnect.18f.gov."
-  type    = "A"
+  type    = "CNAME"
+  ttl     = 120
+  records = ["govconnect.18f.gov.external-domains-production.cloud.gov."]
+}
 
-  alias {
-    name                   = "d1pr8zgciesx6n.cloudfront.net."
-    zone_id                = "${local.cloud_gov_cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
+# govconnect.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "18f_gov__acme_challenge_govconnect_18f_gov_cname" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name    = "_acme-challenge.govconnect.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.govconnect.18f.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "18f_gov_grafana_18f_gov_a" {


### PR DESCRIPTION
Decommissioning based on https://github.com/18F/tts-tech-portfolio/issues/1027.  Need to update DNS to point to the new CG external domain service.