### PR TITLE
Remove govconnect to allow terraform to apply changes to route53

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -529,15 +529,6 @@ resource "aws_route53_record" "18f_gov_fugacious_18f_gov_txt" {
   records = ["d309sw0ah4sgku.cloudfront.net."]
 }
 
-# govconnect.18f.gov — CNAME -------------------------------
-resource "aws_route53_record" "18f_gov_govconnect_18f_gov_cname" {
-  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
-  name    = "govconnect.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["govconnect.18f.gov.external-domains-production.cloud.gov."]
-}
-
 # govconnect.18f.gov acme challenge — CNAME -------------------------------
 resource "aws_route53_record" "18f_gov__acme_challenge_govconnect_18f_gov_cname" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"


### PR DESCRIPTION
Remove records for govconnect.18f.gov and let terraform apply it before creating the new CNAME pointing to the cloud.gov domain broker.  See #506 

Background:  Looking at commit history, I will need to remove the govconnect.18f.gov record and successfully apply the terraform before I can add the new govconnect.18f.gov CNAME record. See #498 and #499
