### PR TITLE
Add govconnect.18f.gov CNAME to cloud.gov external domain endpoint

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -529,6 +529,15 @@ resource "aws_route53_record" "18f_gov_fugacious_18f_gov_txt" {
   records = ["d309sw0ah4sgku.cloudfront.net."]
 }
 
+# govconnect.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "18f_gov_govconnect_18f_gov_cname" {
+  zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"
+  name    = "govconnect.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["govconnect.18f.gov.external-domains-production.cloud.gov."]
+}
+
 # govconnect.18f.gov acme challenge — CNAME -------------------------------
 resource "aws_route53_record" "18f_gov__acme_challenge_govconnect_18f_gov_cname" {
   zone_id = "${aws_route53_zone.18f_gov_zone.zone_id}"


### PR DESCRIPTION
Apart of decommissioning based on 18F/tts-tech-portfolio#1027. Need to add CNAME for govconnect.18f.gov after removing the record #508 
