### PR TITLE
add domain to view federalist queues ui in staging

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -461,6 +461,22 @@ resource "aws_route53_record" "d_18f_gov_acme_challenge_admin_federalistapp_18f_
   records = ["_acme-challenge.admin.federalistapp.18f.gov.external-domains-production.cloud.gov"]
 }
 
+resource "aws_route53_record" "d_18f_gov_queues_federalistapp-staging_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "queues.federalistapp-staging.18f.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["queues.federalistapp-staging.18f.gov.external-domains-production.cloud.gov"]
+}
+
+resource "aws_route53_record" "d_18f_gov_acme_challenge_queues_federalistapp-staging_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.queues.federalistapp-staging.18f.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["_acme-challenge.queues.federalistapp-staging.18f.gov.external-domains-production.cloud.gov"]
+}
+
 resource "aws_route53_record" "d_18f_gov_federalist-builder_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "federalist-builder.18f.gov."


### PR DESCRIPTION
- [ ] This is a new public-facing site <!-- If so, please provide some context and assign to @18F/osc for review. -->
- [ ] Commented with an update to [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) (if applicable)


site is for use by Federalist operators only and requires authentication to access