### PR TITLE
Add AAAA records for v6 enabled alias targets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto3~=1.14.5
 checkdmarc~=4.2.4
 pytest~=5.4.3
+dnspython~=2.1.0

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -18,6 +18,18 @@ resource "aws_route53_record" "d_18f_gov_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d1undivnru8ry9.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_github_18f_gov_txt" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "_github-challenge-18F.18f.gov"
@@ -81,10 +93,34 @@ resource "aws_route53_record" "d_18f_gov_accessibility_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_accessibility_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "accessibility.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d3gg23ftaba0j8.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_ads_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "ads.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d22116wmhcds2y.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_ads_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "ads.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d22116wmhcds2y.cloudfront.net."
@@ -113,10 +149,34 @@ resource "aws_route53_record" "d_18f_gov_agile_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_agile_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "agile.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d2zsago6kfzgka.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_agile-labor-categories_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "agile-labor-categories.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d1p2fryyhm3d02.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_agile-labor-categories_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "agile-labor-categories.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d1p2fryyhm3d02.cloudfront.net."
@@ -145,6 +205,18 @@ resource "aws_route53_record" "d_18f_gov_acqstack-journeymap_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_acqstack-journeymap_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "acqstack-journeymap.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "douocfsg4z7b4.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov__acme-challenge_acqstack_journeymap_18f_gov_txt" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "_acme-challenge.acqstack-journeymap.18f.gov."
@@ -165,6 +237,18 @@ resource "aws_route53_record" "d_18f_gov_api-all-the-x_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_api-all-the-x_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "api-all-the-x.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d2y8d8116udf0m.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_api-program_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "api-program.18f.gov."
@@ -177,10 +261,34 @@ resource "aws_route53_record" "d_18f_gov_api-program_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_api-program_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "api-program.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d1evjsspb8gisi.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_api-usability-testing_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "api-usability-testing.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d1lsalt1zbpjfm.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_api-usability-testing_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "api-usability-testing.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d1lsalt1zbpjfm.cloudfront.net."
@@ -229,10 +337,34 @@ resource "aws_route53_record" "d_18f_gov_automated-testing-playbook_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_automated-testing-playbook_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "automated-testing-playbook.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dieiwe9bk9l6.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_blogging-guide_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "blogging-guide.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d12gmeaikmi2zi.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_blogging-guide_18f_gov_cname_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "blogging-guide.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d12gmeaikmi2zi.cloudfront.net."
@@ -253,10 +385,34 @@ resource "aws_route53_record" "d_18f_gov_before-you-ship_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_before-you-ship_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "before-you-ship.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "daap61vtgsw76.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_boise_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "boise.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d2swak4c9i5bze.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_boise_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "boise.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d2swak4c9i5bze.cloudfront.net."
@@ -277,6 +433,18 @@ resource "aws_route53_record" "d_18f_gov_brand_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "brand.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d19y688vepyspr.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_brand_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "brand.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d19y688vepyspr.cloudfront.net."
@@ -337,10 +505,34 @@ resource "aws_route53_record" "d_18f_gov_content-guide_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_content-guide_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "content-guide.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dv941ubd2f1ex.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_contracting-cookbook_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "contracting-cookbook.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d20pvyni7jlo89.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_contracting-cookbook_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "contracting-cookbook.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d20pvyni7jlo89.cloudfront.net."
@@ -369,10 +561,34 @@ resource "aws_route53_record" "d_18f_gov_design-principles-guide_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_design-principles-guide_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "design-principles-guide.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d3g58t13quzfbr.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_digital-acquisition-playbook_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "digital-acquisition-playbook.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d3f32ju5qz0fej.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_digital-acquisition-playbook_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "digital-acquisition-playbook.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d3f32ju5qz0fej.cloudfront.net."
@@ -393,10 +609,34 @@ resource "aws_route53_record" "d_18f_gov_digitalaccelerator_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_digitalaccelerator_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "digitalaccelerator.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dmsaspwnb8oe8.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_eng-hiring_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "eng-hiring.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d1ju28lhpbkq84.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_eng-hiring_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "eng-hiring.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d1ju28lhpbkq84.cloudfront.net."
@@ -497,6 +737,18 @@ resource "aws_route53_record" "d_18f_gov_federalist-docs_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_federalist-docs_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "federalist-docs.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d5s9igq4dqiuh.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov__acme-challenge_federalist_docs_18f_gov_txt" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "_acme-challenge.federalist-docs.18f.gov."
@@ -587,10 +839,34 @@ resource "aws_route53_record" "d_18f_gov_grouplet-playbook_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_grouplet-playbook_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "grouplet-playbook.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "duek7xmosg5g1.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_guides_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "guides.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d10jxiv8e4xcp7.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_guides_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "guides.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d10jxiv8e4xcp7.cloudfront.net."
@@ -611,10 +887,34 @@ resource "aws_route53_record" "d_18f_gov_guides-template_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_guides-template_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "guides-template.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d2qsfvvx1xjk0n.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_iaa-forms_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "iaa-forms.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d25t6p0vmr5bdy.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_iaa-forms_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "iaa-forms.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d25t6p0vmr5bdy.cloudfront.net."
@@ -647,6 +947,18 @@ resource "aws_route53_record" "d_18f_gov_innovation-toolkit-prototype_18f_gov_a"
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_innovation-toolkit-prototype_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "innovation-toolkit-prototype.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d1n516riijd335.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 #module "d_18f_gov__join_18f_gov_redirect" {
 #  source  = "mediapop/redirect/aws"
 #  version = "1.2.1"
@@ -670,10 +982,34 @@ resource "aws_route53_record" "d_18f_gov_lean-product-design_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_lean-product-design_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "lean-product-design.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d3am6kz2e8wzjv.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_markdown-helper_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "markdown-helper.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "doj9msj2touhw.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_markdown-helper_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "markdown-helper.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "doj9msj2touhw.cloudfront.net."
@@ -694,11 +1030,35 @@ resource "aws_route53_record" "d_18f_gov_methods_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_methods_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "methods.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d2z1u02mjhp26x.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 # Configured with CDN Broker
 resource "aws_route53_record" "d_18f_gov_micropurchase_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "micropurchase.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "dh692qtc0b17x.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_micropurchase_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "micropurchase.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "dh692qtc0b17x.cloudfront.net."
@@ -727,10 +1087,34 @@ resource "aws_route53_record" "d_18f_gov_open-source-guide_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_open-source-guide_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "open-source-guide.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d1lphbkymflb0f.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_open-source-program_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "open-source-program.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d3nhr6mr0xvquu.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_open-source-program_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "open-source-program.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d3nhr6mr0xvquu.cloudfront.net."
@@ -759,6 +1143,18 @@ resource "aws_route53_record" "d_18f_gov_paid-leave-prototype_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_paid-leave-prototype_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "paid-leave-prototype.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d3p6d6b3zaatqv.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov__acme-challenge_paid_leave_prototype_18f_gov_txt" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "_acme-challenge.paid-leave-prototype.18f.gov."
@@ -779,10 +1175,34 @@ resource "aws_route53_record" "d_18f_gov_partnership-playbook_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_partnership-playbook_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "partnership-playbook.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d19eih1husc7rz.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_plain-language-tutorial_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "plain-language-tutorial.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d1cr44lbvuvjia.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_plain-language-tutorial_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "plain-language-tutorial.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d1cr44lbvuvjia.cloudfront.net."
@@ -803,10 +1223,34 @@ resource "aws_route53_record" "d_18f_gov_private-eye_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_private-eye_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "private-eye.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d3asgf5hc4zmll.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_product-guide_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "product-guide.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d2ys0ic6txy8sy.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_product-guide_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "product-guide.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d2ys0ic6txy8sy.cloudfront.net."
@@ -843,6 +1287,18 @@ resource "aws_route53_record" "d_18f_gov_testing-cookbook_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_testing-cookbook_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "testing-cookbook.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d3r30wgm96hxdb.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_tock_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "tock.18f.gov."
@@ -863,10 +1319,34 @@ resource "aws_route53_record" "d_18f_gov_writing-lab-guide_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_writing-lab-guide_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "writing-lab-guide.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d1pjk83agbp9qr.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_www_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "www.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d1undivnru8ry9.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_www_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "www.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d1undivnru8ry9.cloudfront.net."
@@ -911,6 +1391,18 @@ resource "aws_route53_record" "d_18f_gov_agile-bpa_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_agile-bpa_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "agile-bpa.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d2f0yvhrnh42o8.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov__acme-challenge_agile_bpa_18f_gov_txt" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "_acme-challenge.agile-bpa.18f.gov."
@@ -931,6 +1423,18 @@ resource "aws_route53_record" "d_18f_gov_fedspendingtransparency_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_fedspendingtransparency_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "fedspendingtransparency.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d3fi39fc24yqlx.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov__acme-challenge_fedspendingtransparency_18f_gov_txt" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "_acme-challenge.fedspendingtransparency.18f.gov."
@@ -943,6 +1447,18 @@ resource "aws_route53_record" "d_18f_gov_slides_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "slides.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d1g4r1oppplum4.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_slides_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "slides.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d1g4r1oppplum4.cloudfront.net."
@@ -995,6 +1511,18 @@ resource "aws_route53_record" "d_18f_gov_engineering_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_engineering_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "engineering.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d1ah19wbgikahf.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov__acme-challenge_handbook_18f_gov_txt" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "_acme-challenge.handbook.18f.gov."
@@ -1035,10 +1563,34 @@ resource "aws_route53_record" "d_18f_gov_sites-staging_federalist_18f_gov_a" {
   }
 }
 
+resource "aws_route53_record" "d_18f_gov_sites-staging_federalist_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "*.sites-staging.federalist.18f.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d2826r6t5bqji9.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "d_18f_gov_frontend_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "frontend.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "degmwhx2dki4o.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_frontend_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "frontend.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "degmwhx2dki4o.cloudfront.net."
@@ -1059,6 +1611,18 @@ resource "aws_route53_record" "d_18f_gov_demo-er2epz2vb_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "demo-er2epz2vb.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "djut57wuzit2q.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_demo-er2epz2vb_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "demo-er2epz2vb.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "djut57wuzit2q.cloudfront.net."
@@ -1099,6 +1663,18 @@ resource "aws_route53_record" "d_18f_gov_ux-guide_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "ux-guide.18f.gov."
   type    = "A"
+
+  alias {
+    name                   = "d2mhwjcivqpysk.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "d_18f_gov_ux-guide_18f_gov_aaaa" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "ux-guide.18f.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d2mhwjcivqpysk.cloudfront.net."

--- a/terraform/calc.gsa.gov.tf
+++ b/terraform/calc.gsa.gov.tf
@@ -18,6 +18,18 @@ resource "aws_route53_record" "calc_gsa_gov_calc_gsa_gov_a" {
   }
 }
 
+resource "aws_route53_record" "calc_gsa_gov_calc_gsa_gov_aaaa" {
+  zone_id = aws_route53_zone.calc_gsa_gov_zone.zone_id
+  name    = "calc.gsa.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d3ulj13shqrbkv.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "calc_gsa_gov_53401af9bf961a52bf77413b1b769e3d_calc_gsa_gov_cname" {
   zone_id = aws_route53_zone.calc_gsa_gov_zone.zone_id
   name    = "53401af9bf961a52bf77413b1b769e3d.calc.gsa.gov."
@@ -37,7 +49,7 @@ resource "aws_route53_record" "calc_gsa_gov_ea1c6bc2bcfeca68fa3da9697e2b980d_cal
 module "calc_gov__email_security" {
   source = "./email_security"
 
-  zone_id = aws_route53_zone.calc_gsa_gov_zone.zone_id
+  zone_id     = aws_route53_zone.calc_gsa_gov_zone.zone_id
   txt_records = ["v=spf1 include:amazonses.com ~all"]
 }
 

--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -18,10 +18,34 @@ resource "aws_route53_record" "code_gov_apex" {
   }
 }
 
+resource "aws_route53_record" "code_gov_apex_aaaa" {
+  zone_id = aws_route53_zone.code_toplevel.zone_id
+  name    = "code.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dqziuvpgrykcy.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "code_gov_www" {
   zone_id = aws_route53_zone.code_toplevel.zone_id
   name    = "www.code.gov."
   type    = "A"
+
+  alias {
+    name                   = "dqziuvpgrykcy.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "code_gov_www_aaaa" {
+  zone_id = aws_route53_zone.code_toplevel.zone_id
+  name    = "www.code.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "dqziuvpgrykcy.cloudfront.net."
@@ -51,7 +75,7 @@ resource "aws_route53_record" "code_gov_api_cname" {
 }
 
 module "code_gov__email_security" {
-  source = "./email_security"
+  source  = "./email_security"
   zone_id = aws_route53_zone.code_toplevel.zone_id
 }
 

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -24,11 +24,35 @@ resource "aws_route53_record" "digital_gov_apex" {
   }
 }
 
+resource "aws_route53_record" "digital_gov_apex_aaaa" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "digital.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d2q1i25any8vwy.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 # www.digital.gov — redirects to digital.gov through pages_redirect
 resource "aws_route53_record" "digital_gov_www" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
   name    = "www.digital.gov."
   type    = "A"
+
+  alias {
+    name                   = "d11gdxqvugzxkr.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "digital_gov_www_aaaa" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "www.digital.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d11gdxqvugzxkr.cloudfront.net."
@@ -82,8 +106,8 @@ resource "aws_route53_record" "designsystem_digital_gov_aaaa" {
 resource "aws_route53_record" "v2_designsystem_digital_gov_cname" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
   name    = "v2.designsystem.digital.gov."
-  type = "CNAME"
-  ttl = 120
+  type    = "CNAME"
+  ttl     = 120
   records = ["v2.designsystem.digital.gov.external-domains-production.cloud.gov."]
 }
 
@@ -91,8 +115,8 @@ resource "aws_route53_record" "v2_designsystem_digital_gov_cname" {
 resource "aws_route53_record" "acme_challenge_v2_designsystem_digital_gov_cname" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
   name    = "_acme-challenge.v2.designsystem.digital.gov."
-  type = "CNAME"
-  ttl = 120
+  type    = "CNAME"
+  ttl     = 120
   records = ["_acme-challenge.v2.designsystem.digital.gov.external-domains-production.cloud.gov."]
 }
 
@@ -109,6 +133,17 @@ resource "aws_route53_record" "v1_designsystem_digital_gov_a" {
   }
 }
 
+resource "aws_route53_record" "v1_designsystem_digital_gov_aaaa" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "v1.designsystem.digital.gov."
+  type    = "AAAA"
+  alias {
+    name                   = "d5bhevr9bklr9.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 # components.designsystem.digital.gov — CNAME -------------------------------
 resource "aws_route53_record" "components_designsystem_digital_gov_cname" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
@@ -117,7 +152,6 @@ resource "aws_route53_record" "components_designsystem_digital_gov_cname" {
   ttl     = 1800
   records = ["components.designsystem.digital.gov.external-domains-production.cloud.gov."]
 }
-
 
 # _acme-challenge.components.designsystem.digital.gov — CNAME -------------------------------
 resource "aws_route53_record" "_acme-challenge_components_designsystem_digital_gov_cname" {
@@ -140,11 +174,33 @@ resource "aws_route53_record" "public_sans_digital_gov_a" {
   }
 }
 
+resource "aws_route53_record" "public_sans_digital_gov_aaaa" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "public-sans.digital.gov."
+  type    = "AAAA"
+  alias {
+    name                   = "d30jruftdogur6.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 # accessibility.digital.gov — A -------------------------------
 resource "aws_route53_record" "accessibility_digital_gov_a" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
   name    = "accessibility.digital.gov."
   type    = "A"
+  alias {
+    name                   = "d2hlc5rjmtb40x.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "accessibility_digital_gov_aaaa" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "accessibility.digital.gov."
+  type    = "AAAA"
   alias {
     name                   = "d2hlc5rjmtb40x.cloudfront.net."
     zone_id                = local.cloud_gov_cloudfront_zone_id
@@ -164,6 +220,17 @@ resource "aws_route53_record" "demo_accessibility_digital_gov_a" {
   }
 }
 
+resource "aws_route53_record" "demo_accessibility_digital_gov_aaaa" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "demo.accessibility.digital.gov."
+  type    = "AAAA"
+  alias {
+    name                   = "dnt48lkpo0ew7.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 # emerging.digital.gov — CNAME -------------------------------
 resource "aws_route53_record" "emerging_digital_gov_cname" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
@@ -172,7 +239,6 @@ resource "aws_route53_record" "emerging_digital_gov_cname" {
   ttl     = 1800
   records = ["emerging.digital.gov.external-domains-production.cloud.gov."]
 }
-
 
 # _acme-challenge.emerging.digital.gov — CNAME -------------------------------
 resource "aws_route53_record" "_acme-challenge_emerging_digital_gov_cname" {
@@ -195,6 +261,17 @@ resource "aws_route53_record" "pra_digital_gov_a" {
   }
 }
 
+resource "aws_route53_record" "pra_digital_gov_aaaa" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "pra.digital.gov."
+  type    = "AAAA"
+  alias {
+    name                   = "d3vwm5h0acan67.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 # demo.pra.digital.gov — A -------------------------------
 resource "aws_route53_record" "demo_pra_digital_gov_a" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
@@ -207,6 +284,16 @@ resource "aws_route53_record" "demo_pra_digital_gov_a" {
   }
 }
 
+resource "aws_route53_record" "demo_pra_digital_gov_aaaa" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "demo.pra.digital.gov."
+  type    = "AAAA"
+  alias {
+    name                   = "d18cp08a73t0c1.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
 
 # Touchpoints ------------------------------------------------------------------
 # A simple, flexible, and convenient way to collect customer feedback.
@@ -217,6 +304,17 @@ resource "aws_route53_record" "demo_touchpoints_digital_gov_a" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
   name    = "demo.touchpoints.digital.gov."
   type    = "A"
+  alias {
+    name                   = "dcxk3q3d8gzx7.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "demo_touchpoints_digital_gov_aaaa" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "demo.touchpoints.digital.gov."
+  type    = "AAAA"
   alias {
     name                   = "dcxk3q3d8gzx7.cloudfront.net."
     zone_id                = local.cloud_gov_cloudfront_zone_id
@@ -311,6 +409,17 @@ resource "aws_route53_record" "touchpoints_digital_gov_a" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
   name    = "touchpoints.digital.gov."
   type    = "A"
+  alias {
+    name                   = "d5n0pmq4ueiac.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "touchpoints_digital_gov_aaaa" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "touchpoints.digital.gov."
+  type    = "AAAA"
   alias {
     name                   = "d5n0pmq4ueiac.cloudfront.net."
     zone_id                = local.cloud_gov_cloudfront_zone_id
@@ -495,7 +604,6 @@ resource "aws_route53_record" "hubspot_digital_gov_txt" {
     "k=rsa; t=s; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDPtW5iwpXVPiH5FzJ7Nrl8USzuY9zqqzjE0D1r04xDN6qwziDnmgcFNNfMewVKN2D1O+2J9N14hRprzByFwfQW76yojh54Xu3uSbQ3JP0A7k8o8GutRF8zbFUA8n0ZH2y0cIEjMliXY4W4LwPA7m4q0ObmvSjhd63O9d8z1XkUBwIDAQAB"
   ]
 }
-
 
 # END EMAIL NEWSLETTER (HubSpot)
 

--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -11,7 +11,6 @@
 
 # NOTE: digitalgov.gov is a legacy domain that is still hooked up to a number of services in TTS. See the Digital.gov file for more additional records https://github.com/18F/dns/blob/main/terraform/digital.gov.tf
 
-
 # =================================
 
 # INIT
@@ -43,6 +42,17 @@ resource "aws_route53_record" "digitalgov_gov_apex" {
   }
 }
 
+resource "aws_route53_record" "digitalgov_gov_apex_aaaa" {
+  zone_id = aws_route53_zone.digitalgov_gov_zone.zone_id
+  name    = "digitalgov.gov."
+  type    = "AAAA"
+  alias {
+    name                   = "dj62070yqrr60.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 # www.digitalgov.gov — redirects to digital.gov through pages_redirect
 resource "aws_route53_record" "digitalgov_gov_www" {
   zone_id = aws_route53_zone.digitalgov_gov_zone.zone_id
@@ -60,6 +70,17 @@ resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_a" {
   zone_id = aws_route53_zone.digitalgov_gov_zone.zone_id
   name    = "openopps.digitalgov.gov."
   type    = "A"
+  alias {
+    name                   = "d198punmzgrl9l.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "digitalgov_gov_openopps_digitalgov_gov_aaaa" {
+  zone_id = aws_route53_zone.digitalgov_gov_zone.zone_id
+  name    = "openopps.digitalgov.gov."
+  type    = "AAAA"
   alias {
     name                   = "d198punmzgrl9l.cloudfront.net."
     zone_id                = local.cloud_gov_cloudfront_zone_id
@@ -100,7 +121,6 @@ resource "aws_route53_record" "find_digitalgov_gov_a" {
     "digitalgov.sites.infr.search.usa.gov."
   ]
 }
-
 
 # END REDIRECTS
 
@@ -167,13 +187,11 @@ resource "aws_route53_record" "dap_validation_digitalgov_gov_a" {
   ]
 }
 
-
 # END SERVICES
 
 # =================================
 
 # EMAIL and SUPPORT SERVICES
-
 
 # o166.email.digitalgov.gov — A
 # Unclear what this is for.
@@ -304,13 +322,11 @@ resource "aws_route53_record" "digitalgov_gov_email_digitalgov_gov_txt" {
   ]
 }
 
-
 # END EMAIL and SUPPORT SERVICES
 
 # =================================
 
 # EMAIL NEWSLETTER (HubSpot)
-
 
 # connect.digitalgov.gov
 # A former landing page for signing up for the HubSpot newsletter
@@ -396,7 +412,6 @@ resource "aws_route53_record" "hubspot_digitalgov_gov_txt" {
     "k=rsa; t=s; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDPtW5iwpXVPiH5FzJ7Nrl8USzuY9zqqzjE0D1r04xDN6qwziDnmgcFNNfMewVKN2D1O+2J9N14hRprzByFwfQW76yojh54Xu3uSbQ3JP0A7k8o8GutRF8zbFUA8n0ZH2y0cIEjMliXY4W4LwPA7m4q0ObmvSjhd63O9d8z1XkUBwIDAQAB"
   ]
 }
-
 
 # END EMAIL NEWSLETTER (HubSpot)
 

--- a/terraform/discovery.gsa.gov.tf
+++ b/terraform/discovery.gsa.gov.tf
@@ -18,6 +18,18 @@ resource "aws_route53_record" "discovery_gsa_gov_discovery_gsa_gov_a" {
   }
 }
 
+resource "aws_route53_record" "discovery_gsa_gov_discovery_gsa_gov_aaaa" {
+  zone_id = aws_route53_zone.discovery_gsa_gov_zone.zone_id
+  name    = "discovery.gsa.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d11du9vova78yj.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "discovery_gsa_gov_3507f28574ed43c4bd2a644f46b397c0_discovery_gsa_gov_cname" {
   zone_id = aws_route53_zone.discovery_gsa_gov_zone.zone_id
   name    = "3507f28574ed43c4bd2a644f46b397c0.discovery.gsa.gov."

--- a/terraform/findtreatment.gov.tf
+++ b/terraform/findtreatment.gov.tf
@@ -18,6 +18,19 @@ resource "aws_route53_record" "findtreatment_apex" {
   }
 }
 
+resource "aws_route53_record" "findtreatment_apex_aaaa" {
+  zone_id = aws_route53_zone.findtreatment_toplevel.zone_id
+  name    = "findtreatment.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d3qgag0313dgk2.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+
 resource "aws_route53_record" "findtreatment_www" {
   zone_id = aws_route53_zone.findtreatment_toplevel.zone_id
   name    = "www.findtreatment.gov."
@@ -29,6 +42,19 @@ resource "aws_route53_record" "findtreatment_www" {
     evaluate_target_health = false
   }
 }
+
+resource "aws_route53_record" "findtreatment_www_aaaa" {
+  zone_id = aws_route53_zone.findtreatment_toplevel.zone_id
+  name    = "www.findtreatment.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d3qgag0313dgk2.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 
 resource "aws_route53_record" "findtreatment_gov__acme-challenge_findtreatment_gov_txt" {
   zone_id = aws_route53_zone.findtreatment_toplevel.zone_id

--- a/terraform/innovation.gov.tf
+++ b/terraform/innovation.gov.tf
@@ -18,10 +18,34 @@ resource "aws_route53_record" "innovation_gov_apex" {
   }
 }
 
+resource "aws_route53_record" "innovation_gov_apex_aaaa" {
+  zone_id = aws_route53_zone.innovation_toplevel.zone_id
+  name    = "innovation.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d2ntl68ywjm643.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "innovation_gov_www" {
   zone_id = aws_route53_zone.innovation_toplevel.zone_id
   name    = "www.innovation.gov."
   type    = "A"
+
+  alias {
+    name                   = "d2ntl68ywjm643.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "innovation_gov_www_aaaa" {
+  zone_id = aws_route53_zone.innovation_toplevel.zone_id
+  name    = "www.innovation.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d2ntl68ywjm643.cloudfront.net."
@@ -42,8 +66,20 @@ resource "aws_route53_record" "demo_innovation_gov_a" {
   }
 }
 
+resource "aws_route53_record" "demo_innovation_gov_aaaa" {
+  zone_id = aws_route53_zone.innovation_toplevel.zone_id
+  name    = "demo.innovation.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d3am9l7wwd0yie.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 module "innovation_gov__email_security" {
-  source = "./email_security"
+  source  = "./email_security"
   zone_id = aws_route53_zone.innovation_toplevel.zone_id
 }
 

--- a/terraform/open.foia.gov.tf
+++ b/terraform/open.foia.gov.tf
@@ -18,6 +18,19 @@ resource "aws_route53_record" "open_foia_gov_open_foia_gov_a" {
   }
 }
 
+resource "aws_route53_record" "open_foia_gov_open_foia_gov_aaaa" {
+  zone_id = aws_route53_zone.open_foia_gov_zone.zone_id
+  name    = "open.foia.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d23kapr45ru7n0.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+
 resource "aws_route53_record" "open_foia_gov_17fdb56b3309467b9d43ad74888c07e2_open_foia_gov_cname" {
   zone_id = aws_route53_zone.open_foia_gov_zone.zone_id
   name    = "17fdb56b3309467b9d43ad74888c07e2.open.foia.gov."

--- a/terraform/pif.gov.tf
+++ b/terraform/pif.gov.tf
@@ -18,6 +18,18 @@ resource "aws_route53_record" "www" {
   }
 }
 
+resource "aws_route53_record" "www_aaaa" {
+  zone_id = aws_route53_zone.pif_toplevel.zone_id
+  name    = "pif.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dgevgiwb7xxpw.cloudfront.net"
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "mx" {
   zone_id = aws_route53_zone.pif_toplevel.zone_id
   name    = "pif.gov."
@@ -29,7 +41,7 @@ resource "aws_route53_record" "mx" {
 module "pif_gov__email_security" {
   source = "./email_security"
 
-  zone_id = aws_route53_zone.pif_toplevel.zone_id
+  zone_id     = aws_route53_zone.pif_toplevel.zone_id
   txt_records = ["v=spf1 include:gsa.gov ~all"]
 }
 
@@ -101,9 +113,9 @@ resource "aws_route53_record" "proposal_cname" {
 
 resource "aws_route53_record" "proposal_txt" {
   zone_id = aws_route53_zone.pif_toplevel.zone_id
-  name = "_acme-challenge.proposal.pif.gov."
-  type = "TXT"
-  ttl = 120
+  name    = "_acme-challenge.proposal.pif.gov."
+  type    = "TXT"
+  ttl     = 120
   records = ["1dHcUZofJi9on3jRwR4I0o-2fGKbMV0OtmF140lvKmU"]
 }
 
@@ -143,6 +155,18 @@ resource "aws_route53_record" "www-main" {
   zone_id = aws_route53_zone.pif_toplevel.zone_id
   name    = "www.pif.gov."
   type    = "A"
+
+  alias {
+    name                   = "dgevgiwb7xxpw.cloudfront.net"
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "www-main_aaaa" {
+  zone_id = aws_route53_zone.pif_toplevel.zone_id
+  name    = "www.pif.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "dgevgiwb7xxpw.cloudfront.net"

--- a/terraform/plainlanguage.gov.tf
+++ b/terraform/plainlanguage.gov.tf
@@ -18,6 +18,18 @@ resource "aws_route53_record" "plainlanguage_apex_alias" {
   }
 }
 
+resource "aws_route53_record" "plainlanguage_apex_alias_aaaa" {
+  zone_id = aws_route53_zone.plainlanguage_toplevel.zone_id
+  name    = "plainlanguage.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d2uz68wjkv6tls.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "plainlanguage_acme_challenge_cname" {
   zone_id = aws_route53_zone.plainlanguage_toplevel.zone_id
   name    = "_acme-challenge.plainlanguage.gov."
@@ -46,6 +58,18 @@ resource "aws_route53_record" "demo_plainlanguage_a" {
   zone_id = aws_route53_zone.plainlanguage_toplevel.zone_id
   name    = "demo.plainlanguage.gov."
   type    = "A"
+
+  alias {
+    name                   = "d18mn70cbq9e90.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "demo_plainlanguage_aaaa" {
+  zone_id = aws_route53_zone.plainlanguage_toplevel.zone_id
+  name    = "demo.plainlanguage.gov."
+  type    = "AAAA"
 
   alias {
     name                   = "d18mn70cbq9e90.cloudfront.net."

--- a/terraform/presidentialinnovationfellows.gov.tf
+++ b/terraform/presidentialinnovationfellows.gov.tf
@@ -18,6 +18,19 @@ resource "aws_route53_record" "presidentialinnovationfellows_www" {
   }
 }
 
+resource "aws_route53_record" "presidentialinnovationfellows_www_aaaa" {
+  zone_id = aws_route53_zone.presidentialinnovationfellows_toplevel.zone_id
+  name    = "www.presidentialinnovationfellows.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d26prp92rpqmzl.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+
 resource "aws_route53_record" "presidentialinnovationfellows_apex" {
   zone_id = aws_route53_zone.presidentialinnovationfellows_toplevel.zone_id
   name    = "presidentialinnovationfellows.gov."
@@ -29,6 +42,19 @@ resource "aws_route53_record" "presidentialinnovationfellows_apex" {
     evaluate_target_health = false
   }
 }
+
+resource "aws_route53_record" "presidentialinnovationfellows_apex_aaaa" {
+  zone_id = aws_route53_zone.presidentialinnovationfellows_toplevel.zone_id
+  name    = "presidentialinnovationfellows.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d26prp92rpqmzl.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 
 resource "aws_route53_record" "presidentialinnovationfellows_mx" {
   zone_id = aws_route53_zone.presidentialinnovationfellows_toplevel.zone_id

--- a/terraform/search.gov.tf
+++ b/terraform/search.gov.tf
@@ -8,12 +8,24 @@ resource "aws_route53_zone" "search_toplevel" {
 
 resource "aws_route53_record" "search_gov_apex" {
   zone_id = aws_route53_zone.search_toplevel.zone_id
-  name = "search.gov."
-  type = "A"
+  name    = "search.gov."
+  type    = "A"
 
   alias {
-    name = "dcp2c9fh8vtdl.cloudfront.net."
-    zone_id = local.cloud_gov_cloudfront_zone_id
+    name                   = "dcp2c9fh8vtdl.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "search_gov_apex_aaaa" {
+  zone_id = aws_route53_zone.search_toplevel.zone_id
+  name    = "search.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dcp2c9fh8vtdl.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
     evaluate_target_health = false
   }
 }
@@ -21,12 +33,24 @@ resource "aws_route53_record" "search_gov_apex" {
 # www.search.gov — redirects to search.gov through pages_redirect
 resource "aws_route53_record" "search_gov_www" {
   zone_id = aws_route53_zone.search_toplevel.zone_id
-  name = "www.search.gov."
-  type = "A"
+  name    = "www.search.gov."
+  type    = "A"
 
   alias {
-    name = "dv0x4a4ilr842.cloudfront.net."
-    zone_id = local.cloud_gov_cloudfront_zone_id
+    name                   = "dv0x4a4ilr842.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "search_gov_www_aaaa" {
+  zone_id = aws_route53_zone.search_toplevel.zone_id
+  name    = "www.search.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dv0x4a4ilr842.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
     evaluate_target_health = false
   }
 }
@@ -34,17 +58,17 @@ resource "aws_route53_record" "search_gov_www" {
 # find.search.gov
 resource "aws_route53_record" "search_gov_find" {
   zone_id = aws_route53_zone.search_toplevel.zone_id
-  name = "find.search.gov."
-  type = "CNAME"
-  ttl = 5
+  name    = "find.search.gov."
+  type    = "CNAME"
+  ttl     = 5
   records = ["search.usa.gov."]
 }
 
 # admin-center-downtime.search.gov
 resource "aws_route53_record" "search_gov_downtime" {
   zone_id = aws_route53_zone.search_toplevel.zone_id
-  name = "admin-center-downtime.search.gov."
-  type = "A"
+  name    = "admin-center-downtime.search.gov."
+  type    = "A"
   records = ["34.238.89.30"]
   ttl     = "300"
 }
@@ -52,17 +76,17 @@ resource "aws_route53_record" "search_gov_downtime" {
 # Email
 resource "aws_route53_record" "search_gov_mx" {
   zone_id = aws_route53_zone.search_toplevel.zone_id
-  name = "search.gov."
-  type = "MX"
-  ttl = 300
+  name    = "search.gov."
+  type    = "MX"
+  ttl     = 300
   records = ["10 inbound-smtp.us-east-1.amazonaws.com."]
 }
 
 resource "aws_route53_record" "search_gov__amazonses_search_gov_txt" {
   zone_id = aws_route53_zone.search_toplevel.zone_id
-  name = "_amazonses.search.gov."
-  type = "TXT"
-  ttl = 300
+  name    = "_amazonses.search.gov."
+  type    = "TXT"
+  ttl     = 300
   records = ["bhZh0ZXP7e8vJ1zeTFVBUn/n1rE5NHWBzOIgVG71swI="]
 }
 
@@ -94,10 +118,10 @@ resource "aws_route53_record" "search_gov_ses_cname_3" {
 module "search_gov__email_security" {
   source = "./email_security"
 
-  zone_id = aws_route53_zone.search_toplevel.zone_id
+  zone_id     = aws_route53_zone.search_toplevel.zone_id
   txt_records = ["v=spf1 include:amazonses.com include:mail.zendesk.com include:_spf.google.com -all"]
 }
 
 output "search_ns" {
-  value=aws_route53_zone.search_toplevel.name_servers
+  value = aws_route53_zone.search_toplevel.name_servers
 }

--- a/terraform/usability.gov.tf
+++ b/terraform/usability.gov.tf
@@ -3,7 +3,6 @@
 # Before making edits, please reach out to #digitalgov (in TTS Slack) or email digitalgov@gsa.gov
 # ------------------------------------------
 
-
 resource "aws_route53_zone" "usability_toplevel" {
   name = "usability.gov"
   tags = {
@@ -13,12 +12,24 @@ resource "aws_route53_zone" "usability_toplevel" {
 
 resource "aws_route53_record" "usability_gov_apex" {
   zone_id = aws_route53_zone.usability_toplevel.zone_id
-  name = "usability.gov."
-  type = "A"
+  name    = "usability.gov."
+  type    = "A"
 
   alias {
-    name = "d2yghjaoiuwpg5.cloudfront.net."
-    zone_id = local.cloud_gov_cloudfront_zone_id
+    name                   = "d2yghjaoiuwpg5.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "usability_gov_apex_aaaa" {
+  zone_id = aws_route53_zone.usability_toplevel.zone_id
+  name    = "usability.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d2yghjaoiuwpg5.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
     evaluate_target_health = false
   }
 }
@@ -26,16 +37,16 @@ resource "aws_route53_record" "usability_gov_apex" {
 # www.usability.gov — redirects to usability.gov through pages_redirect
 resource "aws_route53_record" "usability_gov_www" {
   zone_id = aws_route53_zone.usability_toplevel.zone_id
-  name = "www.usability.gov."
-  type = "CNAME"
-  ttl = 120
+  name    = "www.usability.gov."
+  type    = "CNAME"
+  ttl     = 120
   records = ["d3882ehkypc0dh.cloudfront.net."]
 }
 
 # Compliance and ACME records -------------------------------
 
 module "usability_gov__email_security" {
-  source = "./email_security"
+  source  = "./email_security"
   zone_id = aws_route53_zone.usability_toplevel.zone_id
 }
 
@@ -44,21 +55,20 @@ module "usability_gov__email_security" {
 # www.usability.gov TXT / ACME Challenge
 resource "aws_route53_record" "www_usability_gov__acme-challenge_txt" {
   zone_id = aws_route53_zone.usability_toplevel.zone_id
-  name = "_acme-challenge.www.usability.gov."
-  type = "TXT"
-  ttl = 120
+  name    = "_acme-challenge.www.usability.gov."
+  type    = "TXT"
+  ttl     = 120
   records = ["9F_gDwJzeGpnWpbGphx1dLYa2GE9EYZuKCEH-qTck-8"]
 }
 
 # usability.gov TXT / ACME Challenge
 resource "aws_route53_record" "usability_gov__acme-challenge_txt" {
   zone_id = aws_route53_zone.usability_toplevel.zone_id
-  name = "_acme-challenge.usability.gov."
-  type = "TXT"
-  ttl = 120
+  name    = "_acme-challenge.usability.gov."
+  type    = "TXT"
+  ttl     = 120
   records = ["mHs3DO2svQSyyvxRfnBP-vlV-ErJr9naPCxhnY_HADI"]
 }
-
 
 output "usability_ns" {
   value = aws_route53_zone.usability_toplevel.name_servers

--- a/terraform/vote.gov.tf
+++ b/terraform/vote.gov.tf
@@ -16,6 +16,17 @@ resource "aws_route53_record" "vote_gov_vote_gov_a" {
   }
 }
 
+resource "aws_route53_record" "vote_gov_vote_gov_aaaa" {
+  zone_id = aws_route53_zone.vote_gov_zone.zone_id
+  name    = "vote.gov."
+  type    = "AAAA"
+  alias {
+    name                   = "d2s5gzwyabrtbd.cloudfront.net"
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "vote_gov_01872332dafeeb93b927e2d9e9b2c53d_vote_gov_cname" {
   zone_id = aws_route53_zone.vote_gov_zone.zone_id
   name    = "01872332dafeeb93b927e2d9e9b2c53d.vote.gov."

--- a/tests/test_missing_aaaa.py
+++ b/tests/test_missing_aaaa.py
@@ -1,0 +1,50 @@
+import boto3
+import dns.resolver
+import dns.exception
+import pytest
+
+
+def get_public_zones():
+    route53 = boto3.client("route53")
+    paginator = route53.get_paginator('list_hosted_zones')
+    zones = {}
+
+    for r in paginator.paginate():
+        zones.update({v['Id']: v['Name'] for v in r['HostedZones'] if v['Config']['PrivateZone'] is False})
+
+    return zones
+
+def get_aliases(zone_id, rr_type):
+    route53 = boto3.client("route53")
+    paginator = route53.get_paginator('list_resource_record_sets')
+    aliases = {}
+
+    for r in paginator.paginate(HostedZoneId=zone_id):
+        aliases.update({
+            v['Name']: v['AliasTarget'] for v in r['ResourceRecordSets'] if (v['Type'] == rr_type and 'AliasTarget' in v)
+        })
+
+    return aliases
+
+def aaaa_available(dns_name):
+    try:
+        dns.resolver.resolve(dns_name, "AAAA")
+        return True
+    except (dns.resolver.NoAnswer, dns.exception.Timeout):
+        pass
+
+    return False
+
+@pytest.mark.parametrize("zone_id,zone_name", get_public_zones().items())
+def test_missing_aaaa_for_v6_enabled_target(zone_id, zone_name):
+    """
+    Look for any alias A records without a matching AAAA record
+    where the alias target does have an AAAA record.
+    """
+    all_a = get_aliases(zone_id, "A")
+    all_aaaa = get_aliases(zone_id, "AAAA")
+    missing = all_a.keys() - all_aaaa.keys()
+
+    available = set([name for name in missing if aaaa_available(all_a[name]['DNSName'])])
+
+    assert available == set()


### PR DESCRIPTION
Federalist managed CloudFront distributions are configured with IPv6
enabled, but many sites are missing the AAAA RRs to direct IPv6
enabled clients to them.

This PR adds AAAA records where the existing A alias points
to a target that has a AAAA record.  Sections were added by script
then verified via a modified /etc/hosts and manual browser check
to verify each site served via IPv6.

This change also adds `tests/test_missing_aaaa.py` which looks
for A aliases in Route53 that point to a v6 enabled target and
have no corresponding AAAA record.   The tests use AWS credentials,
and I am open to suggestions for marking/excluding the tests when
run outside of an AWS session using `@pytest.mark.skipif()`.

<details><summary> Added AAAA FQDN list </summary>

~~~
18f.gov
accessibility.18f.gov
accessibility.digital.gov
acqstack-journeymap.18f.gov
ads.18f.gov
agile.18f.gov
agile-bpa.18f.gov
agile-labor-categories.18f.gov
analytics.usa.gov
api-all-the-x.18f.gov
api-program.18f.gov
api-usability-testing.18f.gov
automated-testing-playbook.18f.gov
before-you-ship.18f.gov
blogging-guide.18f.gov
boise.18f.gov
brand.18f.gov
calc.gsa.gov
code.gov
content-guide.18f.gov
contracting-cookbook.18f.gov
demo.accessibility.digital.gov
demo-er2epz2vb.18f.gov
demo.innovation.gov
demo.plainlanguage.gov
demo.pra.digital.gov
demo.touchpoints.digital.gov
design-principles-guide.18f.gov
designsystem.digital.gov
digitalaccelerator.18f.gov
digital-acquisition-playbook.18f.gov
digital.gov
digitalgov.gov
discovery.gsa.gov
eng-hiring.18f.gov
engineering.18f.gov
federalist-docs.18f.gov
fedspendingtransparency.18f.gov
findtreatment.gov
frontend.18f.gov
grouplet-playbook.18f.gov
guides.18f.gov
guides-template.18f.gov
handbook.18f.gov
iaa-forms.18f.gov
innovation.gov
innovation-toolkit-prototype.18f.gov
lean-product-design.18f.gov
markdown-helper.18f.gov
methods.18f.gov
micropurchase.18f.gov
open.foia.gov
openopps.digitalgov.gov
open-source-guide.18f.gov
open-source-program.18f.gov
paid-leave-prototype.18f.gov
partnership-playbook.18f.gov
pif.gov
plainlanguage.gov
plain-language-tutorial.18f.gov
pra.digital.gov
presidentialinnovationfellows.gov
private-eye.18f.gov
product-guide.18f.gov
public-sans.digital.gov
search.gov
*.sites-staging.federalist.18f.gov
slides.18f.gov
staging.code.gov
testing-cookbook.18f.gov
touchpoints.digital.gov
usability.gov
ux-guide.18f.gov
v1.designsystem.digital.gov
vote.gov
writing-lab-guide.18f.gov
www.18f.gov
www.code.gov
www.digital.gov
www.findtreatment.gov
www.innovation.gov
www.pif.gov
www.presidentialinnovationfellows.gov
www.search.gov
~~~

</details>

- [n/a] This is a new public-facing site _(if so, please follow the additional instructions below)_

