### PR TITLE
Remove dangling records for developers.code.gov and wwwhandbook.18f.gov

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -1015,26 +1015,6 @@ resource "aws_route53_record" "d_18f_gov_handbook_18f_gov_a" {
   }
 }
 
-resource "aws_route53_record" "d_18f_gov__acme-challenge_www_handbook_18f_gov_txt" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "_acme-challenge.wwwhandbook.18f.gov."
-  type    = "TXT"
-  ttl     = 120
-  records = ["BPOzEydsDN3vaYvzfta3AgTm2kqSxB0xBqwYYwfK-pA"]
-}
-
-resource "aws_route53_record" "d_18f_gov_www_handbook_18f_gov_a" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "wwwhandbook.18f.gov."
-  type    = "A"
-
-  alias {
-    name                   = "d36dwgrf0cle4t.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-
 resource "aws_route53_record" "d_18f_gov_sites-staging_federalist_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "_a97eaf263ff636e68fe4c2f55cc71a5b.sites-staging.federalist.18f.gov."

--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -42,18 +42,6 @@ resource "aws_route53_record" "staging_code_gov_a" {
   }
 }
 
-resource "aws_route53_record" "code_gov_developers_code_gov_a" {
-  zone_id = aws_route53_zone.code_toplevel.zone_id
-  name    = "developers.code.gov."
-  type    = "A"
-
-  alias {
-    name                   = "d3jsj3d37agtw.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-
 resource "aws_route53_record" "code_gov_api_cname" {
   zone_id = aws_route53_zone.code_toplevel.zone_id
   name    = "api.code.gov."


### PR DESCRIPTION
While working on #522 I noticed the following:
* wwwhandbook.18f.gov returns:
![image](https://user-images.githubusercontent.com/59626817/125119385-a4e3e300-e0b6-11eb-823f-9cabbebebc08.png)
* developers.code.gov returns:
![image](https://user-images.githubusercontent.com/59626817/125119427-b7f6b300-e0b6-11eb-86d5-59b3e3fd931b.png)

This PR removes the records to prevent confusion and ensure there are no vulnerabilities to any form of dangling DNS attack.

- [n/a] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
