### PR TITLE
Resolve test_missing_aaaa monitor failures due to missing targets and one missing AAAA record

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -815,18 +815,6 @@ resource "aws_route53_record" "d_18f_gov__acme_challenge_govconnect_18f_gov_cnam
   records = ["_acme-challenge.govconnect.18f.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "d_18f_gov_grafana_18f_gov_a" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "grafana.18f.gov."
-  type    = "A"
-
-  alias {
-    name                   = "dualstack.18f-grafana-1906882244.us-east-1.elb.amazonaws.com."
-    zone_id                = local.elb_zone_id
-    evaluate_target_health = false
-  }
-}
-
 resource "aws_route53_record" "d_18f_gov_grouplet-playbook_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "grouplet-playbook.18f.gov."

--- a/terraform/cld.epa.gov.tf
+++ b/terraform/cld.epa.gov.tf
@@ -6,38 +6,6 @@ resource "aws_route53_zone" "cld_epa_gov_zone" {
   }
 }
 
-resource "aws_route53_record" "cld_epa_gov_cld_epa_gov_a" {
-  zone_id = aws_route53_zone.cld_epa_gov_zone.zone_id
-  name    = "cld.epa.gov."
-  type    = "A"
-
-  alias {
-    name                   = "dualstack.cld-epa-gov-el-elb-1vx5r8b4nx40-1695709490.us-east-1.elb.amazonaws.com."
-    zone_id                = local.elb_zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "cld_epa_gov_star_cld_epa_gov_a" {
-  zone_id = aws_route53_zone.cld_epa_gov_zone.zone_id
-  name    = "*.cld.epa.gov."
-  type    = "A"
-
-  alias {
-    name                   = "dualstack.cld-epa-gov-el-elb-1vx5r8b4nx40-1695709490.us-east-1.elb.amazonaws.com."
-    zone_id                = local.elb_zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "cld_epa_gov_727fd0f2717d53b7e842bb638eb4b08b_cld_epa_gov_cname" {
-  zone_id = aws_route53_zone.cld_epa_gov_zone.zone_id
-  name    = "727fd0f2717d53b7e842bb638eb4b08b.cld.epa.gov."
-  type    = "CNAME"
-  ttl     = 300
-  records = ["15bb28ca361cc33db177c9783c8a6a1c5eea0e12.comodoca.com."]
-}
-
 output "cld_epa_gov_ns" {
   value = aws_route53_zone.cld_epa_gov_zone.name_servers
 }

--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -66,6 +66,18 @@ resource "aws_route53_record" "staging_code_gov_a" {
   }
 }
 
+resource "aws_route53_record" "staging_code_gov_aaaa" {
+  zone_id = aws_route53_zone.code_toplevel.zone_id
+  name    = "staging.code.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "d3g0jy911fqt1l.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "code_gov_api_cname" {
   zone_id = aws_route53_zone.code_toplevel.zone_id
   name    = "api.code.gov."

--- a/terraform/gsaforecast.gsa.gov.tf
+++ b/terraform/gsaforecast.gsa.gov.tf
@@ -6,26 +6,6 @@ resource "aws_route53_zone" "gsaforecast_gsa_gov_zone" {
   }
 }
 
-resource "aws_route53_record" "gsaforecast_gsa_gov_gsaforecast_gsa_gov_a" {
-  zone_id = aws_route53_zone.gsaforecast_gsa_gov_zone.zone_id
-  name    = "gsaforecast.gsa.gov."
-  type    = "A"
-
-  alias {
-    name                   = "dualstack.gsaforecast-gsa-gov-34157864.us-east-1.elb.amazonaws.com."
-    zone_id                = local.elb_zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "gsaforecast_gsa_gov_7575ddfce54082fe732d00e132bb2340_gsaforecast_gsa_gov_cname" {
-  zone_id = aws_route53_zone.gsaforecast_gsa_gov_zone.zone_id
-  name    = "7575ddfce54082fe732d00e132bb2340.gsaforecast.gsa.gov."
-  type    = "CNAME"
-  ttl     = 300
-  records = ["6e8adb27ac503c17cd79c9c6f35e7c0f2ea69d53.comodoca.com."]
-}
-
 output "gsaforecast_gsa_gov_ns" {
   value = aws_route53_zone.gsaforecast_gsa_gov_zone.name_servers
 }


### PR DESCRIPTION
Addresses the following issues:
* `gsaforecast.gsa.gov` points to `dualstack.gsaforecast-gsa-gov-34157864.us-east-1.elb.amazonaws.com.` which no longer resolves - Removes `gsaforecast.gsa.gov` and `7575ddfce54082fe732d00e132bb2340.gsaforecast.gsa.gov.` records
* `cld.epa.gov` and `*.cld.epa.gov` point to `dualstack.cld-epa-gov-el-elb-1vx5r8b4nx40-1695709490.us-east-1.elb.amazonaws.com` which no longer resolves - Removes `cld.epa.gov`, `*.cld.epa.gov`, and `727fd0f2717d53b7e842bb638eb4b08b.cld.epa.gov.`
* `grafana.18f.gov` points to `dualstack.18f-grafana-1906882244.us-east-1.elb.amazonaws.com` which no longer resolves - Removes `grafana.18f.gov`
* Adds missing AAAA record for `staging.code.gov`


- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
