### PR TITLE
setup hosted zone for covidtest.usa.gov and staging-covidtest.usa.gov.

### DIFF
--- a/terraform/covidtest.usa.gov.tf
+++ b/terraform/covidtest.usa.gov.tf
@@ -6,20 +6,21 @@ resource "aws_route53_zone" "covidtest_usa_gov_zone" {
   }
 }
 
-resource "aws_route53_record" "covidtest_usa_gov_cname" {
-  zone_id = aws_route53_zone.covidtest_usa_gov_zone.zone_id
-  name    = "covidtest.usa.gov."
-  type    = "CNAME"
-  ttl     = "60"
-  records = ["www.usa.gov"]
-}
-
 resource "aws_route53_zone" "staging_covidtest_usa_gov_zone" {
   name = "staging-covidtest.usa.gov."
 
   tags = {
     Project = "dns"
   }
+}
+
+/* these aren't needed at this point in time. 
+resource "aws_route53_record" "covidtest_usa_gov_cname" {
+  zone_id = aws_route53_zone.covidtest_usa_gov_zone.zone_id
+  name    = "covidtest.usa.gov."
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["www.usa.gov"]
 }
 
 resource "aws_route53_record" "staging_covidtest_usa_gov_cname" {
@@ -29,6 +30,8 @@ resource "aws_route53_record" "staging_covidtest_usa_gov_cname" {
   ttl     = "60"
   records = ["www.usa.gov"]
 }
+*/
+
 
 output "covidtest_usa_gov_ns" {
   value = aws_route53_zone.covidtest_usa_gov_zone.name_servers

--- a/terraform/covidtest.usa.gov.tf
+++ b/terraform/covidtest.usa.gov.tf
@@ -6,14 +6,6 @@ resource "aws_route53_zone" "covidtest_usa_gov_zone" {
   }
 }
 
-resource "aws_route53_zone" "staging_covidtest_usa_gov_zone" {
-  name = "staging-covidtest.usa.gov."
-
-  tags = {
-    Project = "dns"
-  }
-}
-
 resource "aws_route53_record" "covidtest_usa_gov_cname" {
   zone_id = aws_route53_zone.covidtest_usa_gov_zone.zone_id
   name    = "covidtest.usa.gov."
@@ -22,8 +14,16 @@ resource "aws_route53_record" "covidtest_usa_gov_cname" {
   records = ["www.usa.gov"]
 }
 
+resource "aws_route53_zone" "staging_covidtest_usa_gov_zone" {
+  name = "staging-covidtest.usa.gov."
+
+  tags = {
+    Project = "dns"
+  }
+}
+
 resource "aws_route53_record" "staging_covidtest_usa_gov_cname" {
-  zone_id = aws_route53_zone.covidtest_usa_gov_zone.zone_id
+  zone_id = aws_route53_zone.staging_covidtest_usa_gov_zone.zone_id
   name    = "staging-covidtest.usa.gov."
   type    = "CNAME"
   ttl     = "60"

--- a/terraform/covidtest.usa.gov.tf
+++ b/terraform/covidtest.usa.gov.tf
@@ -1,0 +1,39 @@
+resource "aws_route53_zone" "covidtest_usa_gov_zone" {
+  name = "covidtest.usa.gov."
+
+  tags = {
+    Project = "dns"
+  }
+}
+
+resource "aws_route53_zone" "staging_covidtest_usa_gov_zone" {
+  name = "staging-covidtest.usa.gov."
+
+  tags = {
+    Project = "dns"
+  }
+}
+
+resource "aws_route53_record" "covidtest_usa_gov_cname" {
+  zone_id = aws_route53_zone.covidtest_usa_gov_zone.zone_id
+  name    = "covidtest.usa.gov."
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["www.usa.gov"]
+}
+
+resource "aws_route53_record" "staging_covidtest_usa_gov_cname" {
+  zone_id = aws_route53_zone.covidtest_usa_gov_zone.zone_id
+  name    = "staging-covidtest.usa.gov."
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["www.usa.gov"]
+}
+
+output "covidtest_usa_gov_ns" {
+  value = aws_route53_zone.covidtest_usa_gov_zone.name_servers
+}
+
+output "staging_covidtest_usa_gov_ns" {
+  value = aws_route53_zone.staging_covidtest_usa_gov_zone.name_servers
+}


### PR DESCRIPTION
Verify name servers for hosted zones for covidtest.usa.gov and staging-covidtest.usa.gov subdomain. This has been delegated from GSA dns. 

- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
