### PR TITLE
Add acme records for staging-ctusa

### DIFF
--- a/terraform/staging-covidtest.usa.gov.tf
+++ b/terraform/staging-covidtest.usa.gov.tf
@@ -1,0 +1,56 @@
+resource "aws_route53_zone" "stagingcovidtest_usa_gov_zone" {
+  name = "staging-covidtest.usa.gov."
+
+  tags = {
+    Project = "dns"
+  }
+}
+
+/*
+* routes needed, round 1, just ACME records
+*
+* _acme-challenge.${DOMAIN} CNAME -> _acme-challenge.${DOMAIN}.external-domains-production.cloud.gov.
+*
+* Domains:
+* 1) staging-covidtest.usa.gov
+* 2) route.staging-covidtest.usa.gov
+* 3) westb.staging-covidtest.usa.gov
+*/
+
+resource "aws_route53_record" "acme_challenge_stagingcovidtest_usa_gov_cname" {
+  zone_id = aws_route53_zone.stagingcovidtest_usa_gov_zone.zone_id
+  name    = "_acme-challenge.staging-covidtest.usa.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.staging-covidtest.usa.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "acme_challenge_route_stagingcovidtest_usa_gov_cname" {
+  zone_id = aws_route53_zone.stagingcovidtest_usa_gov_zone.zone_id
+  name    = "_acme-challenge.route.staging-covidtest.usa.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.route.staging-covidtest.usa.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "acme_challenge_westb_stagingcovidtest_usa_gov_cname" {
+  zone_id = aws_route53_zone.stagingcovidtest_usa_gov_zone.zone_id
+  name    = "_acme-challenge.westb.staging-covidtest.usa.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.westb.staging-covidtest.usa.gov.external-domains-production.cloud.gov."]
+}
+
+/*
+* routes needed, route 2, real live routes
+*
+* Domains:
+* 1) staging-covidtest.usa.gov -> ALIAS -> cloud front
+* 2) route.staging-covidtest.usa.gov -> latency-based routing -> regional names west.staging... & east.staging...
+* 3) west.staging-covidtest.usa.gov  -> round-robin + health check -> westb and westc
+* 4) westb.staging-covidtest.usa.gov -> ALIAS -> westb ALB
+*/
+
+output "stagingcovidtest_usa_gov_ns" {
+  value = aws_route53_zone.stagingcovidtest_usa_gov_zone.name_servers
+}


### PR DESCRIPTION
add first set of acme-challenge records needed for external-domain-with-cdn use of ctusa staging