### PR TITLE
Delegate staging-ctusa to its own zone

### DIFF
--- a/terraform/staging-covidtest.usa.gov.tf
+++ b/terraform/staging-covidtest.usa.gov.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_zone" "stagingcovidtest_usa_gov_zone" {
-  name = "staging-covidtest.usa.gov."
+  name = "staging-covidtest.usa.gov"
 
   tags = {
     Project = "dns"

--- a/terraform/staging-covidtest.usa.gov.tf
+++ b/terraform/staging-covidtest.usa.gov.tf
@@ -6,6 +6,14 @@ resource "aws_route53_zone" "stagingcovidtest_usa_gov_zone" {
   }
 }
 
+resource "aws_route53_record" "staging-ctusa-ns" {
+  zone_id = aws_route53_zone.usa_gov_zone.zone_id
+  name    = "staging-covidtest.usa.gov"
+  type    = "NS"
+  ttl     = "30"
+  records = aws_route53_zone.stagingcovidtest_usa_gov_zone.name_servers
+}
+
 /*
 * routes needed, round 1, just ACME records
 *

--- a/terraform/usa.gov.tf
+++ b/terraform/usa.gov.tf
@@ -51,6 +51,26 @@ resource "aws_route53_record" "usa_gov_analytics_usa_gov_aaaa" {
 #  redirect_to = "designsystem.digital.gov"
 #}
 
+# CTUSA -------------------------------------------
+#
+# records defined in staging-covidtest.usa.gov.tf & covidtest.usa.gov.tf
+# but need to delegate the zone there to the usa.gov zone here
+
+
+data "aws_route53_zone" "staging_ctusa_zone" {
+  name = "staging-covidtest.usa.gov"
+}
+
+resource "aws_route53_record" "staging-ctusa-ns" {
+  zone_id = aws_route53_zone.usa_gov_zone.zone_id
+  name    = "staging-covidtest.usa.gov"
+  type    = "NS"
+  ttl     = "30"
+  records = data.aws_route53_zone.staging_ctusa_zone.name_servers
+}
+
+# -------------------------------------------------
+
 output "usa_gov_ns" {
   value = aws_route53_zone.usa_gov_zone.name_servers
 }

--- a/terraform/usa.gov.tf
+++ b/terraform/usa.gov.tf
@@ -51,26 +51,6 @@ resource "aws_route53_record" "usa_gov_analytics_usa_gov_aaaa" {
 #  redirect_to = "designsystem.digital.gov"
 #}
 
-# CTUSA -------------------------------------------
-#
-# records defined in staging-covidtest.usa.gov.tf & covidtest.usa.gov.tf
-# but need to delegate the zone there to the usa.gov zone here
-
-
-data "aws_route53_zone" "staging_ctusa_zone" {
-  name = "staging-covidtest.usa.gov"
-}
-
-resource "aws_route53_record" "staging-ctusa-ns" {
-  zone_id = aws_route53_zone.usa_gov_zone.zone_id
-  name    = "staging-covidtest.usa.gov"
-  type    = "NS"
-  ttl     = "30"
-  records = data.aws_route53_zone.staging_ctusa_zone.name_servers
-}
-
-# -------------------------------------------------
-
 output "usa_gov_ns" {
   value = aws_route53_zone.usa_gov_zone.name_servers
 }


### PR DESCRIPTION
Tried to follow the example in `analytics.usa.gov.tf` but it turns out those records aren't active at all. This change should let the records in the staging-ctusa zone be found by DNS clients.

For follow up next week, I'll submit a PR that updates the README to steer users clear of referencing analytics.usa.gov as an example, and see about deleting that file entirely.