### PR TITLE
remove demo.plainlanguage.gov

### DIFF
--- a/terraform/plainlanguage.gov.tf
+++ b/terraform/plainlanguage.gov.tf
@@ -54,30 +54,6 @@ resource "aws_route53_record" "plainlanguage_www_acme_challenge_cname" {
   records = ["_acme-challenge.www.plainlanguage.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "demo_plainlanguage_a" {
-  zone_id = aws_route53_zone.plainlanguage_toplevel.zone_id
-  name    = "demo.plainlanguage.gov."
-  type    = "A"
-
-  alias {
-    name                   = "d18mn70cbq9e90.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "demo_plainlanguage_aaaa" {
-  zone_id = aws_route53_zone.plainlanguage_toplevel.zone_id
-  name    = "demo.plainlanguage.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "d18mn70cbq9e90.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-
 resource "aws_route53_record" "plainlanguage_google_mx" {
   zone_id = aws_route53_zone.plainlanguage_toplevel.zone_id
   name    = "plainlanguage.gov."


### PR DESCRIPTION
- [x] This is decommissioning demo site
   - [x] Provide context - out of date and no longer used
   - [ ] ~Assign to `@18F/osc` for review~
   - [x] [TTS Digital Council's decommissioning process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [x] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
