### PR TITLE
Fix kms alias, upgrade Terraform to 1.1.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,44 +2,46 @@ version: "2.1"
 jobs:
   plan:
     docker:
-      - image: hashicorp/terraform:0.14.7
+      - image: hashicorp/terraform:1.1.5
     steps:
       - checkout
       - run:
           name: Set up Terraform
           # https://discuss.circleci.com/t/create-separate-steps-jobs-for-pr-forks-versus-branches/13419/2
           command: |
+            cd terraform
             if [[ $(echo "$CIRCLE_BRANCH" | grep -c "pull") -gt 0 ]]; then
               echo "This is from a fork."
-              terraform init -backend=false -input=false terraform
+              terraform init -backend=false -input=false
             else
-              terraform init -backend-config=terraform/backend.tfvars -input=false terraform
+              terraform init -backend-config=backend.tfvars -input=false
             fi
       - run:
           name: Validate Terraform config
           command: |
+            cd terraform
             if [[ $(echo "$CIRCLE_BRANCH" | grep -c "pull") -gt 0 ]]; then
               echo "This is from a fork."
-              terraform validate terraform
+              terraform validate
             else
-              terraform plan -input=false terraform
+              terraform plan -input=false
             fi
 
       - persist_to_workspace:
           root: .
           paths:
-            - ./*
+            - ./terraform/*
 
   apply:
     docker:
-      - image: hashicorp/terraform:0.14.7
+      - image: hashicorp/terraform:1.1.5
     steps:
       - attach_workspace:
           at: .
 
       - run:
           name: Deploy the full environment
-          command: terraform apply -input=false -auto-approve terraform
+          command: cd terraform && terraform apply -input=false -auto-approve
 
   validate:
     docker:

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "3.31.0"
   hashes = [
     "h1:AQHoeEquKeICqW0fjUvp/sYNyiGOK9SIQO93y6LZOr0=",
+    "h1:QN/kgOC46kY001+vM/nnmJshzAOnWN+kLLpFG9ALcMU=",
     "zh:07f5b2f4cfaa25e26a4062ac675e3e5aaf65bb21b94b8fd7f30d576398e7410f",
     "zh:08a2154ad29ae130ea9e46948b7b332ec4b45321b4852b45ba60adcfd049f8d6",
     "zh:35ed643c2b999021ad56b49f7d9d3a77c98d152477fe54b5c8a68f696bb1a0b7",

--- a/terraform/cloud.gov.tf
+++ b/terraform/cloud.gov.tf
@@ -2,5 +2,5 @@
 # https://github.com/cloud-gov/cg-provision/blob/master/terraform/stacks/dns/stack.tf
 
 locals {
-  cloud_gov_cloudfront_zone_id      = "Z2FDTNDATAQYW2"
+  cloud_gov_cloudfront_zone_id = "Z2FDTNDATAQYW2"
 }

--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -63,7 +63,7 @@ resource "aws_kms_key" "datagov_zone" {
 
 # Make it easier for admins to identify the key in the KMS console
 resource "aws_kms_alias" "datagov_zone" {
-  name          = "alias/DNSSEC-${aws_route53_zone.datagov_zone.name}"
+  name          = "alias/DNSSEC-${replace(aws_route53_zone.datagov_zone.name, "/[^a-zA-Z0-9:/_-]/", "-")}"
   target_key_id = aws_kms_key.datagov_zone.key_id
 }
 

--- a/terraform/findtreatment.gov.tf
+++ b/terraform/findtreatment.gov.tf
@@ -82,7 +82,7 @@ resource "aws_route53_record" "findtreatment_www_acme_challenge" {
 module "findtreatment_gov__email_security" {
   source = "./email_security"
 
-  zone_id = aws_route53_zone.findtreatment_toplevel.zone_id
+  zone_id   = aws_route53_zone.findtreatment_toplevel.zone_id
   dmarc_rua = "mailto:hhs@rua.agari.com"
   dmarc_ruf = "mailto:hhs@ruf.agari.com"
 }

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -10,7 +10,7 @@ terraform {
     }
   }
 
-  required_version = "~> 0.14.0"
+  required_version = "~> 1.1"
   backend "s3" {
     region = "us-east-1"
   }

--- a/terraform/sbst.gov.tf
+++ b/terraform/sbst.gov.tf
@@ -63,7 +63,7 @@ resource "aws_route53_record" "sbst_gov_6020162f64c7bb016b2a3de7428839d0_www_sbs
 }
 
 module "sbst_gov__email_security" {
-  source = "./email_security"
+  source  = "./email_security"
   zone_id = aws_route53_zone.sbst_gov_zone.zone_id
 }
 


### PR DESCRIPTION
This PR:
- Fixes the illegal alias name for the data.gov DNSSEC key
- Updates Terraform to 1.1.5
- Formats all .tf files canonically

Note that although we are moving from Terraform 0.14 to Terraform 1.0+ here... There is no change in the format of Terraform state files between those versions, and Terraform uses strict semver so this upgrade should be non-controversial.