### PR TITLE
Fix data.gov -> www.data.gov alias

### DIFF
--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -107,7 +107,7 @@ resource "aws_route53_record" "datagov_34193244109_a" {
   type    = "A"
 
   alias {
-    name                   = "www.data.gov"
+    name                   = "www"
     zone_id                = aws_route53_zone.datagov_zone.zone_id
     evaluate_target_health = true
   }


### PR DESCRIPTION
Whoops, the "record in the same Route53 zone" that we point to is actually called "www"

Fixes the botched changeset from https://github.com/18F/dns/pull/581, relates to https://github.com/GSA/datagov-deploy/issues/1001