### PR TITLE
Bypass cloudfront for www.data.gov

### DIFF
--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -874,7 +874,7 @@ resource "aws_route53_record" "datagov_wwwd36thseoamvwaacloudfrontnet_cname" {
   type    = "CNAME"
 
   ttl     = 300
-  records = ["d36thseoamvwaa.cloudfront.net"]
+  records = ["wp-bsp.data.gov"]
 
 }
 


### PR DESCRIPTION
Current data.gov route points to cloudfront. Before moving to the static site on Federalist, we need to take the cloudfront provision down.
This bypasses cloudfront in the short term, before we move to federalist.

Related to https://github.com/GSA/datagov-deploy/issues/3547

- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
