### PR TITLE
Bypass cloudfront for www.data.gov

### DIFF
--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -100,18 +100,18 @@ output "datagov_instructions" {
 }
 
 
-# data.gov is an ALIAS record for www.data.gov
+
+
 resource "aws_route53_record" "datagov_34193244109_a" {
   zone_id = aws_route53_zone.datagov_zone.zone_id
   name    = "data.gov"
   type    = "A"
 
-  alias {
-    name                   = "www"
-    zone_id                = aws_route53_zone.datagov_zone.zone_id
-    evaluate_target_health = true
-  }
+  ttl     = 300
+  records = ["34.193.244.109"]
+
 }
+
 
 resource "aws_route53_record" "datagov_manage101771786_a" {
   zone_id = aws_route53_zone.datagov_zone.zone_id
@@ -874,7 +874,7 @@ resource "aws_route53_record" "datagov_wwwd36thseoamvwaacloudfrontnet_cname" {
   type    = "CNAME"
 
   ttl     = 300
-  records = ["d36thseoamvwaa.cloudfront.net"]
+  records = ["wp-bsp.data.gov"]
 
 }
 


### PR DESCRIPTION
The data.gov team is following this series of actions:
1) PR#1 (this one)
- Unwind #591 and #592 (data.gov can't be an A/ALIAS for www until it's an A record)
- Point www directly to ~cloud.gov~ the origin WP site in FCS (instead of the existing cloudfront for www.data.gov)
2) Remove the existing cloudfront for www.data.gov (out of band, @jbrown-xentity)
3) Ask Federalist to stand up their own cloudfront for www.data.gov (out of band, via @davemcorwin)
4) PR#2 make www an A/ALIAS record for the new cloudfront in the cloud_gov_cloudfront_zone ([similar to example for digital.gov](https://github.com/18F/dns/blob/68fff8934a82861d42d5371a7609deb6f18900b9/terraform/digital.gov.tf#L15-L25))
4) PR#3 redo #592, making data.gov an A/ALIAS for www.data.gov.

This PR supersedes #583.
Related to https://github.com/GSA/datagov-deploy/issues/3547