### PR TITLE
Point data.gov to Federalist

### DIFF
--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -107,9 +107,11 @@ resource "aws_route53_record" "datagov_34193244109_a" {
   name    = "data.gov"
   type    = "A"
 
-  ttl     = 300
-  records = ["34.193.244.109"]
-
+  alias {
+    name                   = "data.gov.external-domains-production.cloud.gov"
+    zone_id                =  local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
 }
 
 


### PR DESCRIPTION
This PR is a draft until @davemcorwin has the Federalist-side cloudfront distro provisioned.

Relates to https://github.com/GSA/datagov-deploy/issues/3547
