### PR TITLE
Update www.data.gov CNAME target to data.gov redirects service

### DIFF
--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -874,8 +874,7 @@ resource "aws_route53_record" "datagov_wwwd36thseoamvwaacloudfrontnet_cname" {
   type    = "CNAME"
 
   ttl     = 300
-  records = ["wp-bsp.data.gov"]
-
+  records = ["developer.data.gov.external-domains-production.cloud.gov"]
 }
 
 resource "aws_route53_record" "datagov_api_ns" {

--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -874,7 +874,7 @@ resource "aws_route53_record" "datagov_wwwd36thseoamvwaacloudfrontnet_cname" {
   type    = "CNAME"
 
   ttl     = 300
-  records = ["developer.data.gov.external-domains-production.cloud.gov"]
+  records = ["www.data.gov.external-domains-production.cloud.gov"]
 }
 
 resource "aws_route53_record" "datagov_api_ns" {


### PR DESCRIPTION
See https://github.com/GSA/datagov-website/pull/23

This needs to stay in draft until [this fix](https://github.com/GSA/datagov-website/pull/24) to that PR is merged and deployed.

Relates to GSA/datagov-deploy#3576

