### PR TITLE
Fix typo lestsencrypt to letsencrypt

### DIFF
--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -143,7 +143,7 @@ resource "aws_route53_record" "datagov__caa" {
   ttl = 300
   records = [
     "0 issue \"awstrust.com\"",
-    "0 issue \"lestsencrypt.org\"",
+    "0 issue \"letsencrypt.org\"",
     "0 issue \"amazonaws.com\"",
     "0 issue \"amazontrust.com\"",
     "0 issue \"digicert.com\"",


### PR DESCRIPTION
- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
