### PR TITLE
add zone id for the cloud.gov external-domains-production record

### DIFF
--- a/terraform/cloud.gov.tf
+++ b/terraform/cloud.gov.tf
@@ -3,4 +3,5 @@
 
 locals {
   cloud_gov_cloudfront_zone_id = "Z2FDTNDATAQYW2"
+  cloud_gov_external_domain_broker_production_zone_id = "Z0495817NJX7TT8AXUM0"
 }

--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -109,7 +109,7 @@ resource "aws_route53_record" "datagov_34193244109_a" {
 
   alias {
     name                   = "data.gov.external-domains-production.cloud.gov"
-    zone_id                =  local.cloud_gov_cloudfront_zone_id
+    zone_id                =  local.cloud_gov_external_domain_broker_production_zone_id
     evaluate_target_health = false
   }
 }


### PR DESCRIPTION
To set a Route53 ALIAS to point to a record somewhere else in Route53, you have to know the zone ID. If you have the wrong zone ID, you see:

```
Error: [ERR]: Error building changeset: InvalidChangeBatch: [Tried to create an alias that targets data.gov.external-domains-production.cloud.gov., type A in zone XXXXXX, but the alias target name does not lie within the target zone]
```

It looks like data.gov is the first to attempt using the external domains broker with an apex domain. The zone ID for the new broker is different from the zone ID for cloudfront distros created before it existed.

This adds the right zone ID, and has the data.gov apex domain ALIAS use it.

Relates to https://github.com/GSA/datagov-deploy/issues/3547