### PR TITLE
Route53 won't alias records in another domain, only "special" domains

### DIFF
--- a/terraform/cloud.gov.tf
+++ b/terraform/cloud.gov.tf
@@ -3,5 +3,4 @@
 
 locals {
   cloud_gov_cloudfront_zone_id = "Z2FDTNDATAQYW2"
-  cloud_gov_external_domain_broker_production_zone_id = "Z0495817NJX7TT8AXUM0"
 }

--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -108,8 +108,8 @@ resource "aws_route53_record" "datagov_34193244109_a" {
   type    = "A"
 
   alias {
-    name                   = "data.gov.external-domains-production.cloud.gov"
-    zone_id                =  local.cloud_gov_external_domain_broker_production_zone_id
+    name                   = "dg7ira9sfp69m.cloudfront.net."
+    zone_id                =  local.cloud_gov_cloudfront_zone_id
     evaluate_target_health = false
   }
 }


### PR DESCRIPTION
...like *.cloudfront.net.

Relates to https://github.com/GSA/datagov-deploy/issues/3547