### PR TITLE
Correct SN SPF, remove ZD

### DIFF
--- a/terraform/digitalgov.gov.tf
+++ b/terraform/digitalgov.gov.tf
@@ -284,7 +284,7 @@ resource "aws_route53_record" "digitalgov_gov_support_digitalgov_gov_txt" {
   type    = "TXT"
   ttl     = "3600"
   records = [
-    "v=spf1 mx a:c.spf.service-now.com include:mail.zendesk.com include:amazonses.com include:1962994.spf05.hubspotemail.net ~all"
+    "v=spf1 mx a:spf.servicenowservices.com include:amazonses.com include:1962994.spf05.hubspotemail.net ~all"
   ]
 }
 


### PR DESCRIPTION
Search.gov is transitioning to use the SN helpdesk tool, and we were given an incorrect SPF record previously. This update fixes that SPF record, and removes our old helpdesk tool.

- [NA] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
