### PR TITLE
 new CNAMEs for the Federalist sites and update the one for atf-eregs.

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -169,13 +169,13 @@ resource "aws_route53_record" "d_18f_gov__acme_challenge_agile-labor-categories_
   records = ["_acme-challenge.agile-labor-categories.18f.gov.external-domains-production.cloud.gov."]
 }
 
-# resource "aws_route53_record" "d_18f_gov_agile-labor-categories_18f_gov_cname" {
-#   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-#   name    = "agile-labor-categories.18f.gov."
-#   type    = "CNAME"
-#   ttl     = 120
-#   records = ["agile-labor-categories.18f.gov.external-domains-production.cloud.gov."]
-# }
+resource "aws_route53_record" "d_18f_gov_agile-labor-categories_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "agile-labor-categories.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["agile-labor-categories.18f.gov.external-domains-production.cloud.gov."]
+}
 
 resource "aws_route53_record" "d_18f_gov_api_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
@@ -297,20 +297,12 @@ resource "aws_route53_record" "d_18f_gov__acme_challenge_atf-eregs_18f_gov_cname
   records = ["_acme-challenge.atf-eregs.18f.gov.external-domains-production.cloud.gov."]
 }
 
-# resource "aws_route53_record" "d_18f_gov_atf-eregs_18f_gov_cname" {
-#   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-#   name    = "atf-eregs.18f.gov."
-#   type    = "CNAME"
-#   ttl     = 120
-#   records = ["atf-eregs.18f.gov.external-domains-production.cloud.gov."]
-# }
-
 resource "aws_route53_record" "d_18f_gov_atf-eregs_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "atf-eregs.18f.gov."
   type    = "CNAME"
-  ttl     = 300
-  records = ["d1a8iv0i0iazmn.cloudfront.net"]
+  ttl     = 120
+  records = ["atf-eregs.18f.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "d_18f_gov_atul-docker-presentation_18f_gov_a" {
@@ -1179,13 +1171,13 @@ resource "aws_route53_record" "d_18f_gov__acme_challenge_private-eye_18f_gov_cna
   records = ["_acme-challenge.private-eye.18f.gov.external-domains-production.cloud.gov."]
 }
 
-# resource "aws_route53_record" "d_18f_gov_private-eye_18f_gov_cname" {
-#   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-#   name    = "private-eye.18f.gov."
-#   type    = "CNAME"
-#   ttl     = 120
-#   records = ["private-eye.18f.gov.external-domains-production.cloud.gov."]
-# }
+resource "aws_route53_record" "d_18f_gov_private-eye_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "private-eye.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["private-eye.18f.gov.external-domains-production.cloud.gov."]
+}
 
 resource "aws_route53_record" "d_18f_gov_product-guide_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id


### PR DESCRIPTION
This is PR #2 to facilitate decommissioning and redirects of

    atf-eregs.18f.gov to redirect to regulations.atf.gov

    private-eye.18f.gov to redirect to https://github.com/18F/private-eye

    agile-labor-categories.18f.gov to redirect to derisking-guide.18f.gov

    Here we add the Acme Challenge CNAMEs so the new CDNs can be provisioned

    Remove the existing A records for the Federalist sites since downtime is acceptable

After #594 is deployed.

- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
