### PR TITLE
Add acme challenge CNAMEs and comment out Federalist CNAMES

### DIFF
--- a/terraform/pif.gov.tf
+++ b/terraform/pif.gov.tf
@@ -127,21 +127,37 @@ resource "aws_route53_record" "fellows_in_innovation_pif_cname" {
   records = ["d3at1jdwnpqw7w.cloudfront.net"]
 }
 
-resource "aws_route53_record" "paygap_pif_cname" {
+resource "aws_route53_record" "d_18f_gov__acme_challenge_paygap_pif_cname" {
   zone_id = aws_route53_zone.pif_toplevel.zone_id
-  name    = "paygap.pif.gov."
+  name    = "_acme-challenge.paygap.pif.gov."
   type    = "CNAME"
-  ttl     = 300
-  records = ["d2qm19v1sj7zt0.cloudfront.net"]
+  ttl     = 120
+  records = ["_acme-challenge.paygap.pif.gov.external-domains-production.cloud.gov."]
+}
+  
+# resource "aws_route53_record" "paygap_pif_cname" {
+#   zone_id = aws_route53_zone.pif_toplevel.zone_id
+#   name    = "paygap.pif.gov."
+#   type    = "CNAME"
+#   ttl     = 300
+#   records = ["d2qm19v1sj7zt0.cloudfront.net"]
+# }
+
+resource "aws_route53_record" "d_18f_gov__acme_challenge_tophealth_pif_cname" {
+  zone_id = aws_route53_zone.pif_toplevel.zone_id
+  name    = "_acme-challenge.tophealth.pif.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.tophealth.pif.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "tophealth_pif_cname" {
-  zone_id = aws_route53_zone.pif_toplevel.zone_id
-  name    = "tophealth.pif.gov."
-  type    = "CNAME"
-  ttl     = 300
-  records = ["d2c5jlxyl3tdbm.cloudfront.net"]
-}
+# resource "aws_route53_record" "tophealth_pif_cname" {
+#  zone_id = aws_route53_zone.pif_toplevel.zone_id
+#  name    = "tophealth.pif.gov."
+#  type    = "CNAME"
+#  ttl     = 300
+#  records = ["d2c5jlxyl3tdbm.cloudfront.net"]
+#}
 
 resource "aws_route53_record" "review_cname" {
   zone_id = aws_route53_zone.pif_toplevel.zone_id

--- a/terraform/pif.gov.tf
+++ b/terraform/pif.gov.tf
@@ -127,7 +127,7 @@ resource "aws_route53_record" "fellows_in_innovation_pif_cname" {
   records = ["d3at1jdwnpqw7w.cloudfront.net"]
 }
 
-resource "aws_route53_record" "d_18f_gov__acme_challenge_paygap_pif_cname" {
+resource "aws_route53_record" "d_pif_gov__acme_challenge_paygap_pif_cname" {
   zone_id = aws_route53_zone.pif_toplevel.zone_id
   name    = "_acme-challenge.paygap.pif.gov."
   type    = "CNAME"
@@ -143,7 +143,7 @@ resource "aws_route53_record" "d_18f_gov__acme_challenge_paygap_pif_cname" {
 #   records = ["d2qm19v1sj7zt0.cloudfront.net"]
 # }
 
-resource "aws_route53_record" "d_18f_gov__acme_challenge_tophealth_pif_cname" {
+resource "aws_route53_record" "d_pif_gov__acme_challenge_tophealth_pif_cname" {
   zone_id = aws_route53_zone.pif_toplevel.zone_id
   name    = "_acme-challenge.tophealth.pif.gov."
   type    = "CNAME"


### PR DESCRIPTION
This is the first of two PRs which will support replacing the former Federalist sites paygap.pif.gov and tophealth.pif.gov with redirects to pif.gov

- This adds the acme challenge CNAMEs for both domains
- This comments out the existing CNAMEs for both domains

The second PR will restore working CNAMEs.