### PR TITLE
Add cname record to mask search.vote.gov for vote.gov

### DIFF
--- a/terraform/vote.gov.tf
+++ b/terraform/vote.gov.tf
@@ -70,7 +70,7 @@ resource "aws_route53_record" "staging_vote_gov_cname" {
   records = ["d3rjcr7wk6cbst.cloudfront.net."]
 }
 
-resource "aws_route53_record" "staging_vote_gov_cname" {
+resource "aws_route53_record" "search_vote_gov_cname" {
   zone_id = aws_route53_zone.vote_gov_zone.zone_id
   name    = "search.vote.gov."
   type    = "CNAME"

--- a/terraform/vote.gov.tf
+++ b/terraform/vote.gov.tf
@@ -70,6 +70,14 @@ resource "aws_route53_record" "staging_vote_gov_cname" {
   records = ["d3rjcr7wk6cbst.cloudfront.net."]
 }
 
+resource "aws_route53_record" "staging_vote_gov_cname" {
+  zone_id = aws_route53_zone.vote_gov_zone.zone_id
+  name    = "search.vote.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["vote-en.sites.infr.search.usa.gov."]
+}
+
 resource "aws_route53_record" "staging_vote_gov_txt" {
   zone_id = aws_route53_zone.vote_gov_zone.zone_id
   name    = "_acme-challenge.staging.vote.gov."


### PR DESCRIPTION
This request is to add a new cname record to mask search.vote.gov for vote.gov follow the guidance here
https://search.gov/admin-center/display/cname.html

At search.vote.gov subdomain we will be hosting a search.gov implemented search page for vote.gov.
