### PR TITLE
Add fac.gov domain TF file

### DIFF
--- a/terraform/fac.gov.tf
+++ b/terraform/fac.gov.tf
@@ -1,0 +1,27 @@
+resource "aws_route53_zone" "fac_gov_zone" {
+  name = "fac.gov."
+
+  tags = {
+    Project = "dns"
+  }
+}
+
+resource "aws_route53_record" "d_fac_gov__acme_challenge_fac_gov_cname" {
+  zone_id = aws_route53_zone.fac_gov_zone.zone_id
+  name    = "_acme-challenge.fac.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.fac.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "d_fac_gov__acme_challenge_wwwfac_cname" {
+  zone_id = aws_route53_zone.fac_gov_zone.zone_id
+  name    = "_acme-challenge.www.fac.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.www.fac.gov.external-domains-production.cloud.gov."]
+}
+
+output "fac_gov_ns" {
+  value = aws_route53_zone.fac_gov_zone.name_servers
+}


### PR DESCRIPTION
- [x] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [x] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information

The Federal Audit Clearinghouse (FAC) is a TTS site being taken over from Census. We have registered fac.gov to point to the new site, however, we wish to put a placeholder page there until the transition is complete. This is to add the domain that will eventually point to the Federalist page for the placeholder site.
