### PR TITLE
Update fac.gov with SPF record for no email

### DIFF
--- a/terraform/fac.gov.tf
+++ b/terraform/fac.gov.tf
@@ -22,6 +22,15 @@ resource "aws_route53_record" "d_fac_gov__acme_challenge_wwwfac_cname" {
   records = ["_acme-challenge.www.fac.gov.external-domains-production.cloud.gov."]
 }
 
+module "fac_gov__email_security" {
+  source = "./email_security"
+
+  zone_id = aws_route53_zone.fac_gov_zone.zone_id
+  txt_records = [
+    local.spf_no_mail
+  ]
+}
+
 output "fac_gov_ns" {
   value = aws_route53_zone.fac_gov_zone.name_servers
 }


### PR DESCRIPTION
- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information

For the [failed checks](https://app.circleci.com/pipelines/github/18F/dns/511/workflows/79bd9134-043e-44b3-93ae-55df5f52f839/jobs/1816), this adds in a SPF record for no email services.