### PR TITLE
Add rest of domains to fac.gov

### DIFF
--- a/terraform/fac.gov.tf
+++ b/terraform/fac.gov.tf
@@ -6,20 +6,36 @@ resource "aws_route53_zone" "fac_gov_zone" {
   }
 }
 
-resource "aws_route53_record" "d_fac_gov__acme_challenge_fac_gov_cname" {
+resource "aws_route53_record" "fac_gov__fac_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "fac.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["fac.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "fac_gov__www_fac_gov_cname" {
+  zone_id = aws_route53_zone.fac_gov_zone.zone_id
+  name    = "www.fac.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["fac.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "fac_gov__acme_challenge_fac_gov_cname" {
   zone_id = aws_route53_zone.fac_gov_zone.zone_id
   name    = "_acme-challenge.fac.gov."
   type    = "CNAME"
-  ttl     = 120
+  ttl     = 60
   records = ["_acme-challenge.fac.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "d_fac_gov__acme_challenge_wwwfac_cname" {
+resource "aws_route53_record" "fac_gov__acme_challenge_www_fac_cname" {
   zone_id = aws_route53_zone.fac_gov_zone.zone_id
   name    = "_acme-challenge.www.fac.gov."
   type    = "CNAME"
-  ttl     = 120
-  records = ["_acme-challenge.www.fac.gov.external-domains-production.cloud.gov."]
+  ttl     = 60
+  records = ["_acme-challenge.fac.gov.external-domains-production.cloud.gov."]
 }
 
 module "fac_gov__email_security" {


### PR DESCRIPTION
- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information

For fac.gov, I added in the acme_challenge.* that Federalist needs, but apparently completely forgot the root domain itself. 🤦‍♀️  This adds those in.
