### PR TITLE
Fix fac.gov Route53 zone ID copy/paste error

### DIFF
--- a/terraform/fac.gov.tf
+++ b/terraform/fac.gov.tf
@@ -7,7 +7,7 @@ resource "aws_route53_zone" "fac_gov_zone" {
 }
 
 resource "aws_route53_record" "fac_gov__fac_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  zone_id = aws_route53_zone.fac_gov_zone.zone_id
   name    = "fac.gov."
   type    = "CNAME"
   ttl     = 60


### PR DESCRIPTION
- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information

Found a copy/paste residual from copying something from 18f.gov to fac.gov. This changes the zone ID back to FAC's own zone.