### PR TITLE
Add fac.gov apex A/AAAA alias records

### DIFF
--- a/terraform/fac.gov.tf
+++ b/terraform/fac.gov.tf
@@ -6,13 +6,29 @@ resource "aws_route53_zone" "fac_gov_zone" {
   }
 }
 
-#resource "aws_route53_record" "fac_gov__fac_gov_cname" {
-#  zone_id = aws_route53_zone.fac_gov_zone.zone_id
-#  name    = "fac.gov."
-#  type    = "CNAME"
-#  ttl     = 60
-#  records = ["fac.gov.external-domains-production.cloud.gov."]
-#}
+resource "aws_route53_record" "fac_gov_apex" {
+  zone_id = aws_route53_zone.fac_gov_zone.zone_id
+  name    = "fac.gov."
+  type    = "A"
+
+  alias {
+    name                   = "fac.gov.external-domains-production.cloud.gov."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "fac_gov_apex_aaaa" {
+  zone_id = aws_route53_zone.fac_gov_zone.zone_id
+  name    = "fac.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "fac.gov.external-domains-production.cloud.gov."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
 
 resource "aws_route53_record" "fac_gov__www_fac_gov_cname" {
   zone_id = aws_route53_zone.fac_gov_zone.zone_id


### PR DESCRIPTION
The fac.gov apex hasn't had a record point to it. (Originally tried CNAMEing it but that didn't work.) This attempts to add the A/AAAA records so it can be aliased for Federalist.