### PR TITLE
feat: Add A and AAAA for fac.gov

### DIFF
--- a/terraform/fac.gov.tf
+++ b/terraform/fac.gov.tf
@@ -6,30 +6,29 @@ resource "aws_route53_zone" "fac_gov_zone" {
   }
 }
 
-# Wait to provision after service is launched
-# resource "aws_route53_record" "fac_gov_fac_gov_apex" {
-#   zone_id = aws_route53_zone.fac_gov_zone.zone_id
-#   name    = "fac.gov."
-#   type    = "A"
+resource "aws_route53_record" "fac_gov_fac_gov_a" {
+  zone_id = aws_route53_zone.fac_gov_zone.zone_id
+  name    = "fac.gov."
+  type    = "A"
 
-#   alias {
-#     name                   = "fac.gov.external-domains-production.cloud.gov."
-#     zone_id                = local.cloud_gov_cloudfront_zone_id
-#     evaluate_target_health = false
-#   }
-# }
+  alias {
+    name                   = "fac.gov.external-domains-production.cloud.gov."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
 
-# resource "aws_route53_record" "fac_gov_fac_gov_apex" {
-#   zone_id = aws_route53_zone.fac_gov_zone.zone_id
-#   name    = "fac.gov."
-#   type    = "AAAA"
+resource "aws_route53_record" "fac_gov_fac_gov_aaaa" {
+  zone_id = aws_route53_zone.fac_gov_zone.zone_id
+  name    = "fac.gov."
+  type    = "AAAA"
 
-#   alias {
-#     name                   = "fac.gov.external-domains-production.cloud.gov."
-#     zone_id                = local.cloud_gov_cloudfront_zone_id
-#     evaluate_target_health = false
-#   }
-# }
+  alias {
+    name                   = "fac.gov.external-domains-production.cloud.gov."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
 
 resource "aws_route53_record" "fac_gov__acme_challenge_fac_gov_cname" {
   zone_id = aws_route53_zone.fac_gov_zone.zone_id


### PR DESCRIPTION
- [X] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - Create apex domain A and AAAA records for fac.gov

_**Note: Testing using the cloud.gov external domains endpoint created by the cloudfront service. If we are unable to provision, we will get the cloudfront distribution url from cloud.gov support**_