### PR TITLE
add validation cname for catalog.data.gov

### DIFF
--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -1099,3 +1099,13 @@ resource "aws_route53_record" "datagov_dmarcvDMARC1prejectfo1pct100ri86400ruamai
 
 }
 
+
+resource "aws_route53_record" "datagov_00bc66d9e476816ba3d1521a99299217catalog8f05f6bd13f92abbf416a1a1bebd7a94xmkpffzlvdacmvalidationsaws_cname" {
+  zone_id = aws_route53_zone.datagov_zone.zone_id
+  name    = "_00bc66d9e476816ba3d1521a99299217.catalog"
+  type    = "CNAME"
+
+  ttl     = 300
+  records = ["_8f05f6bd13f92abbf416a1a1bebd7a94.xmkpffzlvd.acm-validations.aws."]
+
+}


### PR DESCRIPTION
Changing catalog.data.gov certificate issuer from digicert to aws. It needs a cname validation.

- [x] This is NOT a new public-facing site


