### PR TITLE
Establish hosted zone for U.S. Notify

### DIFF
--- a/terraform/notify.gov.tf
+++ b/terraform/notify.gov.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_zone" "notify_gov_zone" {
+    name = "notify.gov."
+
+    tags = {
+        Project = "dns"
+    }
+}


### PR DESCRIPTION
Establishes the hosted zone for notify.gov, which has been approved as the domain name for the new U.S. Notify service being developed by the Public Benefits Studio.

- [x] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [x] Provide context
   - [x] Assign to `@18F/osc` for review
   - [x] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [x] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
