### PR TITLE
Output notify.gov nameservers at end of apply

### DIFF
--- a/terraform/notify.gov.tf
+++ b/terraform/notify.gov.tf
@@ -5,3 +5,7 @@ resource "aws_route53_zone" "notify_gov_zone" {
         Project = "dns"
     }
 }
+
+output "notify_gov_ns" {
+    value = aws_route53_zone.notify_gov_zone.name_servers
+}


### PR DESCRIPTION
Include name servers for notify.gov hosted zone in the outputs so we can give those values to dotgov registrar.