### PR TITLE
Readjust notify.gov SPF record names

### DIFF
--- a/terraform/notify.gov.tf
+++ b/terraform/notify.gov.tf
@@ -61,7 +61,7 @@ resource "aws_route53_record" "notify_gov_dmarc" {
 }
 
 
-resource "aws_route53_record" "notify_gov_spf" {
+resource "aws_route53_record" "notify_gov_root_spf" {
     zone_id = aws_route53_zone.notify_gov_zone.zone_id
     name = "notify.gov"
     type = "TXT"
@@ -70,7 +70,7 @@ resource "aws_route53_record" "notify_gov_spf" {
     records = ["v=spf1 include:amazonses.com -all"]
 }
 
-resource "aws_route53_record" "notify_gov_mail_spf" {
+resource "aws_route53_record" "notify_gov_spf" {
     zone_id = aws_route53_zone.notify_gov_zone.zone_id
     name = "mail"
     type = "TXT"


### PR DESCRIPTION
This gives the original record its name back and the new root record a new name. Hopefully this makes Terraform happy.