### PR TITLE
Reset SPF for notify.gov

### DIFF
--- a/terraform/notify.gov.tf
+++ b/terraform/notify.gov.tf
@@ -60,16 +60,6 @@ resource "aws_route53_record" "notify_gov_dmarc" {
     records = ["v=DMARC1; p=reject; pct=100; fo=1; ri=86400; rua=mailto:notify-support@gsa.gov,mailto:dmarcreports@gsa.gov,mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:notify-support@gsa.gov,mailto:dmarcfailures@gsa.gov"]
 }
 
-
-resource "aws_route53_record" "notify_gov_root_spf" {
-    zone_id = aws_route53_zone.notify_gov_zone.zone_id
-    name = "notify.gov"
-    type = "TXT"
-
-    ttl = 600
-    records = ["v=spf1 include:amazonses.com -all"]
-}
-
 resource "aws_route53_record" "notify_gov_spf" {
     zone_id = aws_route53_zone.notify_gov_zone.zone_id
     name = "mail"


### PR DESCRIPTION
This should help us check whether everything is okay inside of Route 53, after which we can try to apply our changes in a more deliberate way.