### PR TITLE
Add app.fac.gov domain

### DIFF
--- a/terraform/fac.gov.tf
+++ b/terraform/fac.gov.tf
@@ -6,6 +6,17 @@ resource "aws_route53_zone" "fac_gov_zone" {
   }
 }
 
+
+# ACME challege for fac.gov
+resource "aws_route53_record" "fac_gov__acme_challenge_fac_gov_cname" {
+  zone_id = aws_route53_zone.fac_gov_zone.zone_id
+  name    = "_acme-challenge.fac.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["_acme-challenge.fac.gov.external-domains-production.cloud.gov."]
+}
+
+# A record for fac.gov
 resource "aws_route53_record" "fac_gov_fac_gov_a" {
   zone_id = aws_route53_zone.fac_gov_zone.zone_id
   name    = "fac.gov."
@@ -18,6 +29,7 @@ resource "aws_route53_record" "fac_gov_fac_gov_a" {
   }
 }
 
+# AAAA for fac.gov
 resource "aws_route53_record" "fac_gov_fac_gov_aaaa" {
   zone_id = aws_route53_zone.fac_gov_zone.zone_id
   name    = "fac.gov."
@@ -30,22 +42,7 @@ resource "aws_route53_record" "fac_gov_fac_gov_aaaa" {
   }
 }
 
-resource "aws_route53_record" "fac_gov__acme_challenge_fac_gov_cname" {
-  zone_id = aws_route53_zone.fac_gov_zone.zone_id
-  name    = "_acme-challenge.fac.gov."
-  type    = "CNAME"
-  ttl     = 60
-  records = ["_acme-challenge.fac.gov.external-domains-production.cloud.gov."]
-}
-
-resource "aws_route53_record" "fac_gov__www_fac_gov_cname" {
-  zone_id = aws_route53_zone.fac_gov_zone.zone_id
-  name    = "www.fac.gov."
-  type    = "CNAME"
-  ttl     = 60
-  records = ["www.fac.gov.external-domains-production.cloud.gov."]
-}
-
+# ACME challege for www.fac.gov
 resource "aws_route53_record" "fac_gov__acme_challenge_www_fac_cname" {
   zone_id = aws_route53_zone.fac_gov_zone.zone_id
   name    = "_acme-challenge.www.fac.gov."
@@ -54,6 +51,34 @@ resource "aws_route53_record" "fac_gov__acme_challenge_www_fac_cname" {
   records = ["_acme-challenge.www.fac.gov.external-domains-production.cloud.gov."]
 }
 
+# CNAME for www.fac.gov
+resource "aws_route53_record" "fac_gov__www_fac_gov_cname" {
+  zone_id = aws_route53_zone.fac_gov_zone.zone_id
+  name    = "www.fac.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["www.fac.gov.external-domains-production.cloud.gov."]
+}
+
+# ACME challege for app.fac.gov
+resource "aws_route53_record" "fac_gov__acme_challenge_app_fac_gov_cname" {
+  zone_id = aws_route53_zone.fac_gov_zone.zone_id
+  name    = "_acme-challenge.app.fac.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["_acme-challenge.app.fac.gov.external-domains-production.cloud.gov."]
+}
+
+# CNAME for app.fac.gov
+resource "aws_route53_record" "fac_gov__app_fac_gov_cname" {
+  zone_id = aws_route53_zone.fac_gov_zone.zone_id
+  name    = "app.fac.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["www.fac.gov.external-domains-production.cloud.gov."]
+}
+
+# SPF for mail from fac.gov
 module "fac_gov__email_security" {
   source = "./email_security"
 
@@ -64,6 +89,7 @@ module "fac_gov__email_security" {
   ]
 }
 
+# MX records for fac.gov
 resource "aws_route53_record" "fac_gov__mx" {
   zone_id = aws_route53_zone.fac_gov_zone.zone_id
   name    = "fac.gov."


### PR DESCRIPTION
Adds the ACME challenge and the CNAME records for app.cloud.gov as described in [the cloud.gov docs](https://cloud.gov/docs/services/external-domain-service/#how-to-create-an-instance-of-this-service). (The diff looks a little bigger than it actually is due to logical reordering here.)

- [x] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [x] Provide context: This is the app part of fac.gov, where people submit their Single-Audit Checklist (SAC)
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
