### PR TITLE
updates sdg staging and prod to use pages.cloud.gov urls

### DIFF
--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -337,7 +337,7 @@ resource "aws_route53_record" "datagov_sdgd1z5ray7fqefkvcloudfrontnet_cname" {
   type    = "CNAME"
 
   ttl     = 300
-  records = ["d1z5ray7fqefkv.cloudfront.net"]
+  records = ["sdg.data.gov.external-domains-production.cloud.gov"]
 
 }
 
@@ -348,7 +348,7 @@ resource "aws_route53_record" "datagov_sdgstagingdhrxft6loyu0ncloudfrontnet_cnam
   type    = "CNAME"
 
   ttl     = 300
-  records = ["dhrxft6loyu0n.cloudfront.net"]
+  records = ["sdg-staging.data.gov.external-domains-production.cloud.gov."]
 
 }
 
@@ -543,7 +543,7 @@ resource "aws_route53_record" "datagov_acmechallengesdg1cEge5zwHmYap2xfUTEKrx6YW
   type    = "TXT"
 
   ttl     = 300
-  records = ["1cEge-5zwHmYap2xfUTEKrx6YWJuN28yJrJAyQMysXc"]
+  records = ["_acme-challenge.sdg.data.gov.external-domains-production.cloud.gov"]
 
 }
 
@@ -554,7 +554,7 @@ resource "aws_route53_record" "datagov_acmechallengesdgstagingbNsofNEUeS3uTsLwl9
   type    = "TXT"
 
   ttl     = 300
-  records = ["bNsofNEU-eS3uTsLwl9lXkt5OYOVzcE4WXv7LKQGCLQ"]
+  records = ["_acme-challenge.sdg-staging.data.gov.external-domains-production.cloud.gov."]
 
 }
 

--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -348,7 +348,7 @@ resource "aws_route53_record" "datagov_sdgstagingdhrxft6loyu0ncloudfrontnet_cnam
   type    = "CNAME"
 
   ttl     = 300
-  records = ["sdg-staging.data.gov.external-domains-production.cloud.gov."]
+  records = ["sdg-staging.data.gov.external-domains-production.cloud.gov"]
 
 }
 
@@ -554,7 +554,7 @@ resource "aws_route53_record" "datagov_acmechallengesdgstagingbNsofNEUeS3uTsLwl9
   type    = "TXT"
 
   ttl     = 300
-  records = ["_acme-challenge.sdg-staging.data.gov.external-domains-production.cloud.gov."]
+  records = ["_acme-challenge.sdg-staging.data.gov.external-domains-production.cloud.gov"]
 
 }
 

--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -173,7 +173,7 @@ resource "aws_route53_record" "datagov_acmechallengeacmechallengedatagovexternal
   type    = "CNAME"
 
   ttl     = 300
-  records = ["_acme-challenge.data.gov.external-domains-production.cloud.gov"]
+  records = ["_acme-challenge.data.gov.external-domains-production.cloud.gov."]
 
 }
 
@@ -184,7 +184,7 @@ resource "aws_route53_record" "datagov_acmechallengecatalogacmechallengecatalogd
   type    = "CNAME"
 
   ttl     = 300
-  records = ["_acme-challenge.catalog.data.gov.external-domains-production.cloud.gov"]
+  records = ["_acme-challenge.catalog.data.gov.external-domains-production.cloud.gov."]
 
 }
 
@@ -195,7 +195,7 @@ resource "aws_route53_record" "datagov_acmechallengeclimateacmechallengeclimated
   type    = "CNAME"
 
   ttl     = 300
-  records = ["_acme-challenge.climate.data.gov.external-domains-production.cloud.gov"]
+  records = ["_acme-challenge.climate.data.gov.external-domains-production.cloud.gov."]
 
 }
 
@@ -206,7 +206,7 @@ resource "aws_route53_record" "datagov_acmechallengedashboardacmechallengedashbo
   type    = "CNAME"
 
   ttl     = 300
-  records = ["_acme-challenge.dashboard.data.gov.external-domains-production.cloud.gov"]
+  records = ["_acme-challenge.dashboard.data.gov.external-domains-production.cloud.gov."]
 
 }
 
@@ -217,7 +217,7 @@ resource "aws_route53_record" "datagov_acmechallengeinventoryacmechallengeinvent
   type    = "CNAME"
 
   ttl     = 300
-  records = ["_acme-challenge.inventory.data.gov.external-domains-production.cloud.gov"]
+  records = ["_acme-challenge.inventory.data.gov.external-domains-production.cloud.gov."]
 
 }
 
@@ -228,7 +228,7 @@ resource "aws_route53_record" "datagov_acmechallengewwwacmechallengewwwdatagovex
   type    = "CNAME"
 
   ttl     = 300
-  records = ["_acme-challenge.www.data.gov.external-domains-production.cloud.gov"]
+  records = ["_acme-challenge.www.data.gov.external-domains-production.cloud.gov."]
 
 }
 
@@ -261,7 +261,7 @@ resource "aws_route53_record" "datagov_climateclimatedatagovexternaldomainsprodu
   type    = "CNAME"
 
   ttl     = 300
-  records = ["climate.data.gov.external-domains-production.cloud.gov"]
+  records = ["climate.data.gov.external-domains-production.cloud.gov."]
 
 }
 
@@ -272,7 +272,7 @@ resource "aws_route53_record" "datagov_dashboarddashboarddatagovexternaldomainsp
   type    = "CNAME"
 
   ttl     = 300
-  records = ["dashboard.data.gov.external-domains-production.cloud.gov"]
+  records = ["dashboard.data.gov.external-domains-production.cloud.gov."]
 
 }
 
@@ -293,7 +293,7 @@ resource "aws_route53_record" "datagov_inventoryinventorybspdatagov_cname" {
   type    = "CNAME"
 
   ttl     = 300
-  records = ["inventory.data.gov.external-domains-production.cloud.gov"]
+  records = ["inventory.data.gov.external-domains-production.cloud.gov."]
 
 }
 
@@ -337,7 +337,7 @@ resource "aws_route53_record" "datagov_sdgd1z5ray7fqefkvcloudfrontnet_cname" {
   type    = "CNAME"
 
   ttl     = 300
-  records = ["sdg.data.gov.external-domains-production.cloud.gov"]
+  records = ["sdg.data.gov.external-domains-production.cloud.gov."]
 
 }
 
@@ -348,7 +348,7 @@ resource "aws_route53_record" "datagov_sdgstagingdhrxft6loyu0ncloudfrontnet_cnam
   type    = "CNAME"
 
   ttl     = 300
-  records = ["sdg-staging.data.gov.external-domains-production.cloud.gov"]
+  records = ["sdg-staging.data.gov.external-domains-production.cloud.gov."]
 
 }
 
@@ -380,7 +380,7 @@ resource "aws_route53_record" "datagov_wwwd36thseoamvwaacloudfrontnet_cname" {
   type    = "CNAME"
 
   ttl     = 300
-  records = ["www.data.gov.external-domains-production.cloud.gov"]
+  records = ["www.data.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "datagov_api_ns" {
@@ -543,7 +543,7 @@ resource "aws_route53_record" "datagov_acmechallengesdg1cEge5zwHmYap2xfUTEKrx6YW
   type    = "TXT"
 
   ttl     = 300
-  records = ["_acme-challenge.sdg.data.gov.external-domains-production.cloud.gov"]
+  records = ["_acme-challenge.sdg.data.gov.external-domains-production.cloud.gov."]
 
 }
 
@@ -554,7 +554,7 @@ resource "aws_route53_record" "datagov_acmechallengesdgstagingbNsofNEUeS3uTsLwl9
   type    = "TXT"
 
   ttl     = 300
-  records = ["_acme-challenge.sdg-staging.data.gov.external-domains-production.cloud.gov"]
+  records = ["_acme-challenge.sdg-staging.data.gov.external-domains-production.cloud.gov."]
 
 }
 


### PR DESCRIPTION
Updates to Data.gov DNS to address the following:
- pointing DNS for sdg-staging to cloud.gov
- updating SDG DNS from old Cloudfront CDN to new CG urls
- adds optional trailing dot to all data.gov CNAME records to follow docs https://cloud.gov/pages/documentation/custom-domains/#configure-your-dns
- UPDATE: added pretty URLs for catalog-dev & catalog-staging

>>>

- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
