### PR TITLE
Fix type for SDG acme challenge records

### DIFF
--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -562,7 +562,7 @@ resource "aws_route53_record" "datagov_acmechallengeresourcesstagingCTRQ5trgMF0K
 resource "aws_route53_record" "datagov_acmechallengesdg1cEge5zwHmYap2xfUTEKrx6YWJuN28yJrJAyQMysXc_txt" {
   zone_id = aws_route53_zone.datagov_zone.zone_id
   name    = "_acme-challenge.sdg"
-  type    = "TXT"
+  type    = "CNAME"
 
   ttl     = 300
   records = ["_acme-challenge.sdg.data.gov.external-domains-production.cloud.gov."]
@@ -573,7 +573,7 @@ resource "aws_route53_record" "datagov_acmechallengesdg1cEge5zwHmYap2xfUTEKrx6YW
 resource "aws_route53_record" "datagov_acmechallengesdgstagingbNsofNEUeS3uTsLwl9lXkt5OYOVzcE4WXv7LKQGCLQ_txt" {
   zone_id = aws_route53_zone.datagov_zone.zone_id
   name    = "_acme-challenge.sdg-staging"
-  type    = "TXT"
+  type    = "CNAME"
 
   ttl     = 300
   records = ["_acme-challenge.sdg-staging.data.gov.external-domains-production.cloud.gov."]


### PR DESCRIPTION
Follow up to these earlier changes:
- https://github.com/18F/dns/pull/653

- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
