### PR TITLE
Use more acme-challenges for Notify.gov

### DIFF
--- a/terraform/notify.gov.tf
+++ b/terraform/notify.gov.tf
@@ -27,19 +27,19 @@ resource "aws_route53_record" "notify_gov_beta_cname" {
 resource "aws_route53_record" "notify_gov_root_acmechallenge" {
     zone_id = aws_route53_zone.notify_gov_zone.zone_id
     name = "_acme-challenge"
-    type = "CNAME"
+    type = "ALIAS"
 
     ttl = 600
-    records = ["_acme-challenge.beta.notify.gov.external-domains-production.cloud.gov"]
+    records = ["_acme-challenge.notify.gov.external-domains-production.cloud.gov"]
 }
 
 resource "aws_route53_record" "notify_gov_root_cname" {
     zone_id = aws_route53_zone.notify_gov_zone.zone_id
     name = ""
-    type = "CNAME"
+    type = "ALIAS"
 
     ttl = 600
-    records = ["beta.notify.gov.external-domains-production.cloud.gov"]
+    records = ["notify.gov.external-domains-production.cloud.gov"]
 }
 
 resource "aws_route53_record" "notify_gov_dkim0" {

--- a/terraform/notify.gov.tf
+++ b/terraform/notify.gov.tf
@@ -24,22 +24,22 @@ resource "aws_route53_record" "notify_gov_beta_cname" {
     records = ["beta.notify.gov.external-domains-production.cloud.gov"]
 }
 
-resource "aws_route53_record" "notify_gov_root_acmechallenge" {
+resource "aws_route53_record" "notify_gov_apex_acmechallenge" {
     zone_id = aws_route53_zone.notify_gov_zone.zone_id
     name = "_acme-challenge"
-    type = "ALIAS"
+    type = "CNAME"
 
     ttl = 600
     records = ["_acme-challenge.notify.gov.external-domains-production.cloud.gov"]
 }
 
-resource "aws_route53_record" "notify_gov_root_cname" {
+resource "aws_route53_record" "notify_gov_www_acmechallenge" {
     zone_id = aws_route53_zone.notify_gov_zone.zone_id
-    name = ""
-    type = "ALIAS"
+    name = "_acme-challenge.www"
+    type = "CNAME"
 
     ttl = 600
-    records = ["notify.gov.external-domains-production.cloud.gov"]
+    records = ["_acme-challenge.www.notify.gov.external-domains-production.cloud.gov"]
 }
 
 resource "aws_route53_record" "notify_gov_dkim0" {


### PR DESCRIPTION
Adding the records needed to add a new domain service with CDN, according to the instructions in https://cloud.gov/docs/services/external-domain-service/