### PR TITLE
add CNAME and acme-challenge for guides.18f.gov

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -783,6 +783,24 @@ resource "aws_route53_record" "d_18f_gov_guides_18f_gov_aaaa" {
   }
 }
 
+# guides.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_guides_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "guides.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["guides.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# guides.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_guides_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.guides.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.guides.18f.gov.external-domains-production.cloud.gov."]
+}
+
 resource "aws_route53_record" "d_18f_gov_guides-template_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "guides-template.18f.gov."


### PR DESCRIPTION
- [X] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [X] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information

Context:
I'm working on migrating the 18f.guides.gov domain to the external domain service, so that we can start using it with the cloud pages application that is the new home of the 18F guides and methods
