### PR TITLE
Update agile.18f.gov dns to CNAMEs

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -137,28 +137,20 @@ resource "aws_route53_record" "d_18f_gov__acme-challenge_ads_18f_gov_txt" {
   records = ["fXfES1KVPHxh87Y9iMVwl_ezEGRpKagAL7EzQpuYaBI"]
 }
 
-resource "aws_route53_record" "d_18f_gov_agile_18f_gov_a" {
+resource "aws_route53_record" "d_18f_gov__acme_challenge_agile_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "agile.18f.gov."
-  type    = "A"
-
-  alias {
-    name                   = "d2zsago6kfzgka.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  name    = "_acme-challenge.agile.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.agile.18f.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "d_18f_gov_agile_18f_gov_aaaa" {
+resource "aws_route53_record" "d_18f_gov_agile_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "agile.18f.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "d2zsago6kfzgka.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  type    = "CNAME"
+  ttl     = 120
+  records = ["agile.18f.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "d_18f_gov__acme_challenge_agile-labor-categories_18f_gov_cname" {


### PR DESCRIPTION
- Updates agile.18f.gov to work with cloud.gov's external domain service
