### PR TITLE
Remove agile.18f.gov temporarily to clear old records

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -137,21 +137,21 @@ resource "aws_route53_record" "d_18f_gov__acme-challenge_ads_18f_gov_txt" {
   records = ["fXfES1KVPHxh87Y9iMVwl_ezEGRpKagAL7EzQpuYaBI"]
 }
 
-resource "aws_route53_record" "d_18f_gov__acme_challenge_agile_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "_acme-challenge.agile.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["_acme-challenge.agile.18f.gov.external-domains-production.cloud.gov."]
-}
+# resource "aws_route53_record" "d_18f_gov__acme_challenge_agile_18f_gov_cname" {
+#   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+#   name    = "_acme-challenge.agile.18f.gov."
+#   type    = "CNAME"
+#   ttl     = 120
+#   records = ["_acme-challenge.agile.18f.gov.external-domains-production.cloud.gov."]
+# }
 
-resource "aws_route53_record" "d_18f_gov_agile_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "agile.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["agile.18f.gov.external-domains-production.cloud.gov."]
-}
+# resource "aws_route53_record" "d_18f_gov_agile_18f_gov_cname" {
+#   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+#   name    = "agile.18f.gov."
+#   type    = "CNAME"
+#   ttl     = 120
+#   records = ["agile.18f.gov.external-domains-production.cloud.gov."]
+# }
 
 resource "aws_route53_record" "d_18f_gov__acme_challenge_agile-labor-categories_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id


### PR DESCRIPTION
Temporarily remove agile.18f.gov so TF can remove old DNS records without conflict of new records.