### PR TITLE
18F guides dns updates

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -477,28 +477,20 @@ resource "aws_route53_record" "d_18f_gov_compliance-viewer_18f_gov_cname" {
   records = ["dw68mooipdgv2.cloudfront.net"]
 }
 
-resource "aws_route53_record" "d_18f_gov_content-guide_18f_gov_a" {
+resource "aws_route53_record" "d_18f_gov__acme_challenge_content-guide_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "content-guide.18f.gov."
-  type    = "A"
-
-  alias {
-    name                   = "dv941ubd2f1ex.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  name    = "_acme-challenge.content-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.content-guide.18f.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "d_18f_gov_content-guide_18f_gov_aaaa" {
+resource "aws_route53_record" "d_18f_gov_content-guide_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "content-guide.18f.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "dv941ubd2f1ex.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  type    = "CNAME"
+  ttl     = 120
+  records = ["content-guide.18f.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "d_18f_gov_contracting-cookbook_18f_gov_a" {

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -421,28 +421,20 @@ resource "aws_route53_record" "d_18f_gov__acme-challenge_boise_18f_gov_txt" {
   records = ["wtVQL98OnnahVdqneIGLrHfMAD30e7JWDOFouTenqaM"]
 }
 
-resource "aws_route53_record" "d_18f_gov_brand_18f_gov_a" {
+resource "aws_route53_record" "d_18f_gov__acme_challenge_brand_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "brand.18f.gov."
-  type    = "A"
-
-  alias {
-    name                   = "d19y688vepyspr.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  name    = "_acme-challenge.brand.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.brand.18f.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "d_18f_gov_brand_18f_gov_aaaa" {
+resource "aws_route53_record" "d_18f_gov_brand_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "brand.18f.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "d19y688vepyspr.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  type    = "CNAME"
+  ttl     = 120
+  records = ["brand.18f.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "d_18f_gov_c6769c03c29466618a6bd23b158d28a6_18f_gov_cname" {

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -1497,28 +1497,20 @@ resource "aws_route53_record" "d_18f_gov__acme-challenge_federalist-proxysite-te
   records = ["qiz18V0W9mHROFHTHqE4_Bn8NIByqMhoLvkKQ3h4Zxg"]
 }
 
-resource "aws_route53_record" "d_18f_gov_ux-guide_18f_gov_a" {
+resource "aws_route53_record" "d_18f_gov__acme_challenge_ux-guide_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "ux-guide.18f.gov."
-  type    = "A"
-
-  alias {
-    name                   = "d2mhwjcivqpysk.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  name    = "_acme-challenge.ux-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.ux-guide.18f.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "d_18f_gov_ux-guide_18f_gov_aaaa" {
+resource "aws_route53_record" "d_18f_gov_ux-guide_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "ux-guide.18f.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "d2mhwjcivqpysk.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  type    = "CNAME"
+  ttl     = 120
+  records = ["ux-guide.18f.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "d_18f_gov__acme-challenge_ux-guide_18f_gov_txt" {

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -1309,28 +1309,20 @@ resource "aws_route53_record" "d_18f_gov__acme-challenge_engineering_18f_gov_txt
   records = ["oI10GrfMLy5l2eczdrgMGsCHAooCAvbsq8yQA2Dhvbs"]
 }
 
-resource "aws_route53_record" "d_18f_gov_engineering_18f_gov_a" {
+resource "aws_route53_record" "d_18f_gov__acme_challenge_engineering_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "engineering.18f.gov."
-  type    = "A"
-
-  alias {
-    name                   = "d1ah19wbgikahf.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  name    = "_acme-challenge.engineering.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.engineering.18f.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "d_18f_gov_engineering_18f_gov_aaaa" {
+resource "aws_route53_record" "d_18f_gov_engineering_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "engineering.18f.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "d1ah19wbgikahf.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  type    = "CNAME"
+  ttl     = 120
+  records = ["engineering.18f.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "d_18f_gov__acme_challenge_handbook_18f_gov_cname" {

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -1053,28 +1053,20 @@ resource "aws_route53_record" "d_18f_gov_private-eye_18f_gov_cname" {
   records = ["private-eye.18f.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "d_18f_gov_product-guide_18f_gov_a" {
+resource "aws_route53_record" "d_18f_gov__acme_challenge_product-guide_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "product-guide.18f.gov."
-  type    = "A"
-
-  alias {
-    name                   = "d2ys0ic6txy8sy.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  name    = "_acme-challenge.product-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.product-guide.18f.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "d_18f_gov_product-guide_18f_gov_aaaa" {
+resource "aws_route53_record" "d_18f_gov_product-guide_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "product-guide.18f.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "d2ys0ic6txy8sy.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  type    = "CNAME"
+  ttl     = 120
+  records = ["product-guide.18f.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "d_18f_gov_requests_18f_gov_cname" {

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -81,28 +81,20 @@ resource "aws_route53_record" "d_18f_gov_89afa0142502f9be9fba3afd80a703e1_18f_go
 
 # Individual site records start here, alphabetized by subdomain name
 
-resource "aws_route53_record" "d_18f_gov_accessibility_18f_gov_a" {
+resource "aws_route53_record" "d_18f_gov__acme_challenge_accessibility_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "accessibility.18f.gov."
-  type    = "A"
-
-  alias {
-    name                   = "d3gg23ftaba0j8.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  name    = "_acme-challenge.accessibility.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.accessibility.18f.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "d_18f_gov_accessibility_18f_gov_aaaa" {
+resource "aws_route53_record" "d_18f_gov_accessibility_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "accessibility.18f.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "d3gg23ftaba0j8.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  type    = "CNAME"
+  ttl     = 120
+  records = ["accessibility.18f.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "d_18f_gov_ads_18f_gov_a" {

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -597,28 +597,20 @@ resource "aws_route53_record" "d_18f_gov_digitalaccelerator_18f_gov_aaaa" {
   }
 }
 
-resource "aws_route53_record" "d_18f_gov_eng-hiring_18f_gov_a" {
+resource "aws_route53_record" "d_18f_gov__acme_challenge_eng-hiring_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "eng-hiring.18f.gov."
-  type    = "A"
-
-  alias {
-    name                   = "d1ju28lhpbkq84.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  name    = "_acme-challenge.eng-hiring.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.eng-hiring.18f.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "d_18f_gov_eng-hiring_18f_gov_aaaa" {
+resource "aws_route53_record" "d_18f_gov_eng-hiring_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "eng-hiring.18f.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "d1ju28lhpbkq84.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  type    = "CNAME"
+  ttl     = 120
+  records = ["eng-hiring.18f.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "d_18f_gov_federalist_18f_gov_cname" {


### PR DESCRIPTION
This is part of [18F guides migration](https://gsa-tts.slack.com/archives/C03LHEFGSF7) work, following these [steps](https://cloud.gov/2021/08/16/external-domain-migration-announcement/) and using [this example](https://github.com/18F/dns/pull/668/files). 

These are not new sites, just updates to existing sites.  

- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
