### PR TITLE
Add cnames for remaining 18F guides

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -1512,14 +1512,6 @@ resource "aws_route53_record" "d_18f_gov__acme-challenge_federalist-proxysite-te
   records = ["qiz18V0W9mHROFHTHqE4_Bn8NIByqMhoLvkKQ3h4Zxg"]
 }
 
-resource "aws_route53_record" "d_18f_gov__acme-challenge_ux-guide_18f_gov_txt" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "_acme-challenge.ux-guide.18f.gov."
-  type    = "TXT"
-  ttl     = 120
-  records = ["cMHSS7E7SJghSFKvmy-K8Cp78eZ8ihZjzESAuyEi5eY"]
-}
-
 # ux-guide.18f.gov acme challenge — CNAME -------------------------------
 resource "aws_route53_record" "d_18f_gov__acme_challenge_ux-guide_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -81,6 +81,24 @@ resource "aws_route53_record" "d_18f_gov_89afa0142502f9be9fba3afd80a703e1_18f_go
 
 # Individual site records start here, alphabetized by subdomain name
 
+# accessibility.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_accessibility_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.accessibility.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.accessibility.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# accessibility.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_accessibility_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "accessibility.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["accessibility.18f.gov.external-domains-production.cloud.gov."]
+}
+
 resource "aws_route53_record" "d_18f_gov_ads_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "ads.18f.gov."
@@ -405,6 +423,24 @@ resource "aws_route53_record" "d_18f_gov__acme-challenge_boise_18f_gov_txt" {
   records = ["wtVQL98OnnahVdqneIGLrHfMAD30e7JWDOFouTenqaM"]
 }
 
+# brand.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_brand_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.brand.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.brand.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# brand.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_brand_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "brand.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["brand.18f.gov.external-domains-production.cloud.gov."]
+}
+
 resource "aws_route53_record" "d_18f_gov_c6769c03c29466618a6bd23b158d28a6_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "c6769c03c29466618a6bd23b158d28a6.18f.gov."
@@ -443,6 +479,25 @@ resource "aws_route53_record" "d_18f_gov_compliance-viewer_18f_gov_cname" {
   type    = "CNAME"
   ttl     = 300
   records = ["dw68mooipdgv2.cloudfront.net"]
+}
+
+
+# content-guide.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_content-guide_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.content-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.content-guide.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# content-guide.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_content-guide_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "content-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["content-guide.18f.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "d_18f_gov_contracting-cookbook_18f_gov_a" {
@@ -547,6 +602,25 @@ resource "aws_route53_record" "d_18f_gov_digitalaccelerator_18f_gov_aaaa" {
     zone_id                = local.cloud_gov_cloudfront_zone_id
     evaluate_target_health = false
   }
+}
+
+
+# eng-hiring.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_eng-hiring_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.eng-hiring.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.eng-hiring.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# eng-hiring.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_eng-hiring_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "eng-hiring.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["eng-hiring.18f.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "d_18f_gov_federalist_18f_gov_cname" {
@@ -989,6 +1063,25 @@ resource "aws_route53_record" "d_18f_gov_private-eye_18f_gov_cname" {
   records = ["private-eye.18f.gov.external-domains-production.cloud.gov."]
 }
 
+
+# product-guide.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_product-guide_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.product-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.product-guide.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# product-guide.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_product-guide_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "product-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["product-guide.18f.gov.external-domains-production.cloud.gov."]
+}
+
 resource "aws_route53_record" "d_18f_gov_requests_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "requests.18f.gov."
@@ -1221,6 +1314,24 @@ resource "aws_route53_record" "d_18f_gov__acme-challenge_engineering_18f_gov_txt
   records = ["oI10GrfMLy5l2eczdrgMGsCHAooCAvbsq8yQA2Dhvbs"]
 }
 
+# engineering.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_engineering_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.engineering.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.engineering.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# engineering.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_engineering_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "engineering.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["engineering.18f.gov.external-domains-production.cloud.gov."]
+}
+
 resource "aws_route53_record" "d_18f_gov__acme_challenge_handbook_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "_acme-challenge.handbook.18f.gov."
@@ -1409,6 +1520,24 @@ resource "aws_route53_record" "d_18f_gov__acme-challenge_ux-guide_18f_gov_txt" {
   records = ["cMHSS7E7SJghSFKvmy-K8Cp78eZ8ihZjzESAuyEi5eY"]
 }
 
+# ux-guide.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_ux-guide_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.ux-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.ux-guide.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# ux-guide.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_ux-guide_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "ux-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["ux-guide.18f.gov.external-domains-production.cloud.gov."]
+}
+
 # portfolios.18f.gov — CNAME -------------------------------
 # step 1 of https://cloud.gov/docs/services/external-domain-service/#how-to-create-an-instance-of-this-service
 resource "aws_route53_record" "d_18f_gov_portfolios_18f_gov_cname" {
@@ -1521,131 +1650,4 @@ resource "aws_route53_record" "d_18f_gov__acme_challenge_queues_federalistapp_18
   type    = "CNAME"
   ttl     = 120
   records = ["_acme-challenge.queues.federalistapp.18f.gov.external-domains-production.cloud.gov."]
-}
-
-# accessibility.18f.gov acme challenge — CNAME -------------------------------
-resource "aws_route53_record" "d_18f_gov__acme_challenge_accessibility_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "_acme-challenge.accessibility.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["_acme-challenge.accessibility.18f.gov.external-domains-production.cloud.gov."]
-}
-
-# accessibility.18f.gov — CNAME -------------------------------
-resource "aws_route53_record" "d_18f_gov_accessibility_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "accessibility.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["accessibility.18f.gov.external-domains-production.cloud.gov."]
-}
-
-
-# brand.18f.gov acme challenge — CNAME -------------------------------
-resource "aws_route53_record" "d_18f_gov__acme_challenge_brand_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "_acme-challenge.brand.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["_acme-challenge.brand.18f.gov.external-domains-production.cloud.gov."]
-}
-
-# brand.18f.gov — CNAME -------------------------------
-resource "aws_route53_record" "d_18f_gov_brand_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "brand.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["brand.18f.gov.external-domains-production.cloud.gov."]
-}
-
-# content-guide.18f.gov acme challenge — CNAME -------------------------------
-resource "aws_route53_record" "d_18f_gov__acme_challenge_content-guide_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "_acme-challenge.content-guide.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["_acme-challenge.content-guide.18f.gov.external-domains-production.cloud.gov."]
-}
-
-# content-guide.18f.gov — CNAME -------------------------------
-resource "aws_route53_record" "d_18f_gov_content-guide_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "content-guide.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["content-guide.18f.gov.external-domains-production.cloud.gov."]
-}
-
-# eng-hiring.18f.gov acme challenge — CNAME -------------------------------
-resource "aws_route53_record" "d_18f_gov__acme_challenge_eng-hiring_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "_acme-challenge.eng-hiring.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["_acme-challenge.eng-hiring.18f.gov.external-domains-production.cloud.gov."]
-}
-
-# eng-hiring.18f.gov — CNAME -------------------------------
-resource "aws_route53_record" "d_18f_gov_eng-hiring_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "eng-hiring.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["eng-hiring.18f.gov.external-domains-production.cloud.gov."]
-}
-
-# product-guide.18f.gov acme challenge — CNAME -------------------------------
-resource "aws_route53_record" "d_18f_gov__acme_challenge_product-guide_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "_acme-challenge.product-guide.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["_acme-challenge.product-guide.18f.gov.external-domains-production.cloud.gov."]
-}
-
-# product-guide.18f.gov — CNAME -------------------------------
-resource "aws_route53_record" "d_18f_gov_product-guide_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "product-guide.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["product-guide.18f.gov.external-domains-production.cloud.gov."]
-}
-
-# engineering.18f.gov acme challenge — CNAME -------------------------------
-resource "aws_route53_record" "d_18f_gov__acme_challenge_engineering_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "_acme-challenge.engineering.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["_acme-challenge.engineering.18f.gov.external-domains-production.cloud.gov."]
-}
-
-# engineering.18f.gov — CNAME -------------------------------
-resource "aws_route53_record" "d_18f_gov_engineering_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "engineering.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["engineering.18f.gov.external-domains-production.cloud.gov."]
-}
-
-# ux-guide.18f.gov acme challenge — CNAME -------------------------------
-resource "aws_route53_record" "d_18f_gov__acme_challenge_ux-guide_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "_acme-challenge.ux-guide.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["_acme-challenge.ux-guide.18f.gov.external-domains-production.cloud.gov."]
-}
-
-# ux-guide.18f.gov — CNAME -------------------------------
-resource "aws_route53_record" "d_18f_gov_ux-guide_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "ux-guide.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["ux-guide.18f.gov.external-domains-production.cloud.gov."]
 }

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -1522,3 +1522,130 @@ resource "aws_route53_record" "d_18f_gov__acme_challenge_queues_federalistapp_18
   ttl     = 120
   records = ["_acme-challenge.queues.federalistapp.18f.gov.external-domains-production.cloud.gov."]
 }
+
+# accessibility.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_accessibility_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.accessibility.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.accessibility.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# accessibility.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_accessibility_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "accessibility.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["accessibility.18f.gov.external-domains-production.cloud.gov."]
+}
+
+
+# brand.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_brand_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.brand.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.brand.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# brand.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_brand_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "brand.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["brand.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# content-guide.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_content-guide_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.content-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.content-guide.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# content-guide.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_content-guide_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "content-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["content-guide.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# eng-hiring.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_eng-hiring_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.eng-hiring.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.eng-hiring.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# eng-hiring.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_eng-hiring_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "eng-hiring.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["eng-hiring.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# product-guide.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_product-guide_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.product-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.product-guide.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# product-guide.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_product-guide_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "product-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["product-guide.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# engineering.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_engineering_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.engineering.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.engineering.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# engineering.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_engineering_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "engineering.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["engineering.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# ux-guide.18f.gov acme challenge — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov__acme_challenge_ux-guide_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.ux-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.ux-guide.18f.gov.external-domains-production.cloud.gov."]
+}
+
+# ux-guide.18f.gov — CNAME -------------------------------
+resource "aws_route53_record" "d_18f_gov_ux-guide_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "ux-guide.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["ux-guide.18f.gov.external-domains-production.cloud.gov."]
+}


### PR DESCRIPTION
**IS BLOCKED BY #672** 

- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
