### PR TITLE
re-enable redirect for atf-eregs

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -291,13 +291,13 @@ resource "aws_route53_record" "d_18f_gov__acme_challenge_atf-eregs_18f_gov_cname
 #   records = ["d1a8iv0i0iazmn.cloudfront.net"]
 # }
 
-resource "aws_route53_record" "d_18f_gov_atf-eregs_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "atf-eregs.18f.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["atf-eregs.18f.gov.external-domains-production.cloud.gov."]
-}
+# resource "aws_route53_record" "d_18f_gov_atf-eregs_18f_gov_cname" {
+#   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+#   name    = "atf-eregs.18f.gov."
+#   type    = "CNAME"
+#   ttl     = 120
+#   records = ["atf-eregs.18f.gov.external-domains-production.cloud.gov."]
+# }
 
 resource "aws_route53_record" "d_18f_gov_atul-docker-presentation_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -283,21 +283,21 @@ resource "aws_route53_record" "d_18f_gov__acme_challenge_atf-eregs_18f_gov_cname
   records = ["_acme-challenge.atf-eregs.18f.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "d_18f_gov_atf-eregs_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "atf-eregs.18f.gov."
-  type    = "CNAME"
-  ttl     = 300
-  records = ["d1a8iv0i0iazmn.cloudfront.net"]
-}
-
 # resource "aws_route53_record" "d_18f_gov_atf-eregs_18f_gov_cname" {
 #   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
 #   name    = "atf-eregs.18f.gov."
 #   type    = "CNAME"
-#   ttl     = 120
-#   records = ["atf-eregs.18f.gov.external-domains-production.cloud.gov."]
+#   ttl     = 300
+#   records = ["d1a8iv0i0iazmn.cloudfront.net"]
 # }
+
+resource "aws_route53_record" "d_18f_gov_atf-eregs_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "atf-eregs.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["atf-eregs.18f.gov.external-domains-production.cloud.gov."]
+}
 
 resource "aws_route53_record" "d_18f_gov_atul-docker-presentation_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id


### PR DESCRIPTION
To finish #576 - re-enabling the original external domain configuration for atf-eregs.18f.gov and disabling the CNAME record that points directly to a cloudfront domain. 

Needed to enable a permanent redirect in the pages-redirects repo in this PR https://github.com/cloud-gov/pages-redirects/pull/233.


