### PR TITLE
Added redirect for accessibility.digital.gov

### DIFF
--- a/terraform/accessibility.digital.gov.tf
+++ b/terraform/accessibility.digital.gov.tf
@@ -1,0 +1,11 @@
+# redirect accessibility.digital.gov to https://wwww.digital.gov/guides/accessibility-for-teams
+# module "d_18f_gov__join_18f_gov_redirect" {
+#  source  = "mediapop/redirect/aws"
+#  version = "1.2.1"
+#
+#  domains = {
+#    "accessibility.digital.gov " = ["accessibility.digital.gov "]
+#  }
+#
+#  redirect_to = "https://wwww.digital.gov/guides/accessibility-for-teams"
+#}


### PR DESCRIPTION
### Summary

- Redirect https://accessibility.digital.gov/ to www.digital.gov/guides/accessibility-for-teams
