### PR TITLE
Update usability.gov and accessibility.digital.gov DNS to prep redirects

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -186,50 +186,27 @@ resource "aws_route53_record" "public_sans_digital_gov_aaaa" {
 }
 
 # accessibility.digital.gov — A -------------------------------
-resource "aws_route53_record" "accessibility_digital_gov_a" {
+# *NOTE: Temporarily delete this record so it can be updated
+#        to the new external domain service convention in cloud.gov.
+# resource "aws_route53_record" "accessibility_digital_gov_a" {
+#   zone_id = aws_route53_zone.digital_toplevel.zone_id
+#   name    = "accessibility.digital.gov."
+#   type    = "A"
+#   alias {
+#     name                   = "d2hlc5rjmtb40x.cloudfront.net."
+#     zone_id                = local.cloud_gov_cloudfront_zone_id
+#     evaluate_target_health = false
+#   }
+# }
+
+resource "aws_route53_record" "_acme-challenge_accessibility_digital_gov_cname" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "accessibility.digital.gov."
-  type    = "A"
-  alias {
-    name                   = "d2hlc5rjmtb40x.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
+  name    = "_acme-challenge.accessibility.digital.gov."
+  type    = "CNAME"
+  ttl     = 1800
+  records = ["_acme-challenge.accessibility.digital.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "accessibility_digital_gov_aaaa" {
-  zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "accessibility.digital.gov."
-  type    = "AAAA"
-  alias {
-    name                   = "d2hlc5rjmtb40x.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-
-# demo.accessibility.digital.gov — A -------------------------------
-resource "aws_route53_record" "demo_accessibility_digital_gov_a" {
-  zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "demo.accessibility.digital.gov."
-  type    = "A"
-  alias {
-    name                   = "dnt48lkpo0ew7.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "demo_accessibility_digital_gov_aaaa" {
-  zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "demo.accessibility.digital.gov."
-  type    = "AAAA"
-  alias {
-    name                   = "dnt48lkpo0ew7.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
 
 # emerging.digital.gov — CNAME -------------------------------
 resource "aws_route53_record" "emerging_digital_gov_cname" {

--- a/terraform/usability.gov.tf
+++ b/terraform/usability.gov.tf
@@ -35,13 +35,15 @@ resource "aws_route53_record" "usability_gov_apex_aaaa" {
 }
 
 # www.usability.gov — redirects to usability.gov through pages_redirect
-resource "aws_route53_record" "usability_gov_www" {
-  zone_id = aws_route53_zone.usability_toplevel.zone_id
-  name    = "www.usability.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["d3882ehkypc0dh.cloudfront.net."]
-}
+# *NOTE: Temporarily delete this record so it can be updated
+#        to the new external domain service convention in cloud.gov.
+# resource "aws_route53_record" "usability_gov_www" {
+#   zone_id = aws_route53_zone.usability_toplevel.zone_id
+#   name    = "www.usability.gov."
+#   type    = "CNAME"
+#   ttl     = 120
+#   records = ["d3882ehkypc0dh.cloudfront.net."]
+# }
 
 # Compliance and ACME records -------------------------------
 
@@ -52,22 +54,22 @@ module "usability_gov__email_security" {
 
 # ACME Challenge records
 
-# www.usability.gov TXT / ACME Challenge
-resource "aws_route53_record" "www_usability_gov__acme-challenge_txt" {
-  zone_id = aws_route53_zone.usability_toplevel.zone_id
-  name    = "_acme-challenge.www.usability.gov."
-  type    = "TXT"
-  ttl     = 120
-  records = ["9F_gDwJzeGpnWpbGphx1dLYa2GE9EYZuKCEH-qTck-8"]
-}
-
-# usability.gov TXT / ACME Challenge
-resource "aws_route53_record" "usability_gov__acme-challenge_txt" {
+# usability.gov CNAME / ACME Challenge
+resource "aws_route53_record" "usability_gov__acme-challenge_cname" {
   zone_id = aws_route53_zone.usability_toplevel.zone_id
   name    = "_acme-challenge.usability.gov."
-  type    = "TXT"
+  type    = "CNAME"
   ttl     = 120
-  records = ["mHs3DO2svQSyyvxRfnBP-vlV-ErJr9naPCxhnY_HADI"]
+  records = ["_acme-challenge.usability.gov.external-domains-production.cloud.gov."]
+}
+
+# www.usability.gov CNAME / ACME Challenge
+resource "aws_route53_record" "www_usability_gov__acme-challenge_cname" {
+  zone_id = aws_route53_zone.usability_toplevel.zone_id
+  name    = "_acme-challenge.www.usability.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.www.usability.gov.external-domains-production.cloud.gov."]
 }
 
 output "usability_ns" {


### PR DESCRIPTION
This PR is in preparation for the www.usability.gov and accessibility.digital.gov redirects. 

- [X] It updates the ACME Challenge records for usability.gov, www.usability.gov, and accessibility.digital.gov based on the current [external domain service](https://cloud.gov/docs/services/external-domain-service/#how-to-create-an-instance-of-this-service) provided by cloud.gov.
- [X] It removes the defunct demo.accessibility.digital.gov DNS records
- [X] It temporarily removes the A records for accessibility.digital.gov and www.usability.gov in order to update them to CNAME records in a follow up PR.