### PR TITLE
Enable SPF validation for Touchpoints emails

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -479,6 +479,30 @@ resource "aws_route53_record" "touchpoints_digital_gov_ses_cname_3" {
   records = ["pwa5cvp3cde3aghrojag7ketcjaeytp2.dkim.amazonses.com"]
 }
 
+resource "aws_route53_record" "touchpoints_digital_gov_dkim_1" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "q7e7jvcl23omte4fum6jgp5lpwgxdp7a._domainkey.touchpoints.digital.gov"
+  type    = "CNAME"
+  ttl     = 1800
+  records = ["q7e7jvcl23omte4fum6jgp5lpwgxdp7a.dkim.amazonses.com"]
+}
+
+resource "aws_route53_record" "touchpoints_digital_gov_dkim_2" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "y5bm3fsnhjdr5ar2qwyneeiy7wr5c64e._domainkey.touchpoints.digital.gov"
+  type    = "CNAME"
+  ttl     = 1800
+  records = ["y5bm3fsnhjdr5ar2qwyneeiy7wr5c64e.dkim.amazonses.com"]
+}
+
+resource "aws_route53_record" "touchpoints_digital_gov_dkim_3" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "anyljchthsaitorr6matbfeoeyug34jh._domainkey.touchpoints.digital.gov"
+  type    = "CNAME"
+  ttl     = 1800
+  records = ["anyljchthsaitorr6matbfeoeyug34jh.dkim.amazonses.com"]
+}
+
 # Touchpoints APP / MX Records
 # app.touchpoints.digital.gov
 resource "aws_route53_record" "touchpoints_digital_gov_mx" {

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -515,6 +515,24 @@ resource "aws_route53_record" "touchpoints_digital_gov_mx" {
   ]
 }
 
+resource "aws_route53_record" "mail_from_touchpoints_digital_gov_mx" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "mail.touchpoints.digital.gov"
+  type    = "MX"
+  ttl     = "600"
+  records = [
+    "10 feedback-smtp.us-east-1.amazonses.com"
+  ]
+}
+
+resource "aws_route53_record" "touchpoints_digital_gov_spf" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name = "mail.touchpoints.digital.gov"
+  type = "TXT"
+  ttl = 600
+  records = ["v=spf1 include:amazonses.com ~all"]
+}
+
 # Compliance and ACME records -------------------------------
 
 module "digital_gov__email_security" {


### PR DESCRIPTION
Improve Touchpoints email deliverability by enabling SPF validation (DKIM validation is already enabled). Touchpoints uses AWS SES.

Changes enacted by this PR:

1. Verify 'touchpoints.digital.gov' as an SES identity by adding DKIM records for the domain.
3. Add subdomain 'mail.touchpoints.digital.gov' as our custom `mail from` domain by adding an MX record for it.
4. Add an SPF record for 'mail.touchpoints.digital.gov'.