### PR TITLE
Add benefits.gov and  govloans.gov domains

### DIFF
--- a/terraform/benefits.gov.tf
+++ b/terraform/benefits.gov.tf
@@ -44,6 +44,13 @@ resource "aws_route53_record" "benefits_gov_www_acmechallenge" {
   records = ["_acme-challenge.www.benefits.gov.external-domains-production.cloud.gov."]
 }
 
+resource "aws_route53_record" "benefits_gov_ssabest_acmechallenge" {
+  zone_id = aws_route53_zone.benefits_gov_zone.zone_id
+  name    = "_acme-challenge.ssabest.benefits.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["_acme-challenge.ssabest.benefits.gov.external-domains-production.cloud.gov."]
+
 resource "aws_route53_record" "benefits_gov_ssabest" {
   zone_id = aws_route53_zone.benefits_gov_zone.zone_id
   name    = "ssabest.benefits.gov."

--- a/terraform/benefits.gov.tf
+++ b/terraform/benefits.gov.tf
@@ -50,6 +50,7 @@ resource "aws_route53_record" "benefits_gov_ssabest_acmechallenge" {
   type    = "CNAME"
   ttl     = 300
   records = ["_acme-challenge.ssabest.benefits.gov.external-domains-production.cloud.gov."]
+}
 
 resource "aws_route53_record" "benefits_gov_ssabest" {
   zone_id = aws_route53_zone.benefits_gov_zone.zone_id

--- a/terraform/benefits.gov.tf
+++ b/terraform/benefits.gov.tf
@@ -1,0 +1,72 @@
+resource "aws_route53_zone" "benefits_gov_zone" {
+  name = "benefits.gov"
+
+  tags = {
+    Project = "dns"
+  }
+}
+
+resource "aws_route53_record" "benefits_gov_apex" {
+  zone_id = aws_route53_zone.benefits_gov_zone.zone_id
+  name    = "benefits.gov."
+  type    = "A"
+  alias {
+    name                   = "d3bi0ia5r11uox.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "benefits_gov_apex_aaaa" {
+  zone_id = aws_route53_zone.benefits_gov_zone.zone_id
+  name    = "benefits.gov."
+  type    = "AAAA"
+  alias {
+    name                   = "d3bi0ia5r11uox.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "benefits_gov_acmechallenge" {
+  zone_id = aws_route53_zone.benefits_gov_zone.zone_id
+  name    = "_acme-challenge.benefits.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["_acme-challenge.benefits.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "benefits_gov_www_acmechallenge" {
+  zone_id = aws_route53_zone.benefits_gov_zone.zone_id
+  name    = "_acme-challenge.www.benefits.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["_acme-challenge.www.benefits.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "benefits_gov_ssabest" {
+  zone_id = aws_route53_zone.benefits_gov_zone.zone_id
+  name    = "ssabest.benefits.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["ssabest.benefits.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "benefits_gov_www" {
+  zone_id = aws_route53_zone.benefits_gov_zone.zone_id
+  name    = "www.benefits.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["www.benefits.gov.external-domains-production.cloud.gov."]
+}
+
+module "benefits_gov_emailsecurity" {
+  source = "./email_security"
+
+  zone_id = aws_route53_zone.benefits_gov_zone.zone_id
+  txt_records = ["v=spf1 -all"]
+}
+
+output "benefits_gov_ns" {
+  value = aws_route53_zone.benefits_gov_zone.name_servers
+}

--- a/terraform/govloans.gov.tf
+++ b/terraform/govloans.gov.tf
@@ -1,0 +1,64 @@
+resource "aws_route53_zone" "govloans_gov_zone" {
+  name = "govloans.gov"
+
+  tags = {
+    Project = "dns"
+  }
+}
+
+resource "aws_route53_record" "govloans_gov_apex" {
+  zone_id = aws_route53_zone.govloans_gov_zone.zone_id
+  name    = "govloans.gov."
+  type    = "A"
+  alias {
+    name                   = "d2pvs1juwa2drp.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "govloans_gov_apex_aaaa" {
+  zone_id = aws_route53_zone.govloans_gov_zone.zone_id
+  name    = "govloans.gov."
+  type    = "AAAA"
+  alias {
+    name                   = "d2pvs1juwa2drp.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "govloans_gov_acmechallenge" {
+  zone_id = aws_route53_zone.govloans_gov_zone.zone_id
+  name    = "_acme-challenge.govloans.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["_acme-challenge.govloans.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "govloans_gov_www_acmechallenge" {
+  zone_id = aws_route53_zone.govloans_gov_zone.zone_id
+  name    = "_acme-challenge.www.govloans.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["_acme-challenge.www.govloans.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "govloans_gov_www" {
+  zone_id = aws_route53_zone.govloans_gov_zone.zone_id
+  name    = "www.govloans.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["www.govloans.gov.external-domains-production.cloud.gov."]
+}
+
+module "govloans_gov_emailsecurity" {
+  source = "./email_security"
+
+  zone_id = aws_route53_zone.govloans_gov_zone.zone_id
+  txt_records = ["v=spf1 -all"]
+}
+
+output "govloans_gov_ns" {
+  value = aws_route53_zone.govloans_gov_zone.name_servers
+}


### PR DESCRIPTION
Benefits.gov and GovLoans.gov are being transferred to GSA from DOL.  The domains will simply redirect to a new customer experience on USA.gov for finding about government benefits and will become part of the USA.gov system.
