### PR TITLE
Update search.gov.tf

### DIFF
--- a/terraform/search.gov.tf
+++ b/terraform/search.gov.tf
@@ -68,8 +68,8 @@ resource "aws_route53_record" "search_gov_find" {
 resource "aws_route53_record" "search_gov_downtime" {
   zone_id = aws_route53_zone.search_toplevel.zone_id
   name    = "admin-center-downtime.search.gov."
-  type    = "A"
-  records = ["34.238.89.30"]
+  type    = "CNAME"
+  records = ["admin-center-downtime.search.usa.gov."]
   ttl     = "300"
 }
 


### PR DESCRIPTION
Direct admin-center-downtime to a record we control within our AWS account

- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@18F/osc` for review
   - [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
