### PR TITLE
Add CNAME for standards.digital.gov

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -581,6 +581,26 @@ resource "aws_route53_record" "touchpoints_digital_gov__acme-challenge_txt" {
   records = ["Ho5lFIaJK7J44nLyBWGpfMBRNc96eL7-QnMuBII-4Uc"]
 }
 
+# standards.digital.gov — CNAME -------------------------------
+# (Redirects to standards.digital.gov via "pages redirect")
+resource "aws_route53_record" "standards_digital_gov_cname" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "standards.digital.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["standards.digital.gov.external-domains-production.cloud.gov."]
+}
+
+# standards.digital.gov — CNAME -------------------------------
+# (Redirects to standards.digital.gov via "pages redirect")
+resource "aws_route53_record" "_acme-challenge_standards_digital_gov_cname" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "_acme-challenge.standards.digital.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.standards.digital.gov.external-domains-production.cloud.gov."]
+}
+
 # =================================
 
 # EMAIL NEWSLETTER (HubSpot)


### PR DESCRIPTION
We're planning to launch standards.digital.gov on 9/26. We want to switch to the standards.digital.gov URL on 9/23. The site is currently at https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/site/gsa-tts/federal-website-standards/.

- [x] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [x] Provide context
   - [x] Assign to `@18F/osc` for review
   - [x] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [x] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information (Requested access)
