### PR TITLE
Upgrade DNS to new Cloud.gov DNS

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -542,15 +542,6 @@ resource "aws_route53_record" "pra_digital_gov__acme-challenge_txt" {
   records = ["0VxlpUbA2CXBDx1GKUlr-SujwU0ep9KvGrM0BvE6o4E"]
 }
 
-# demo.pra.digital.gov TXT / ACME Challenge
-resource "aws_route53_record" "demo_pra_digital_gov__acme-challenge_txt" {
-  zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "_acme-challenge.demo.pra.digital.gov."
-  type    = "TXT"
-  ttl     = 120
-  records = ["qzIXA_qU7a3io8b_FRxFVbPBUKZ83XtglufzS7qKnlg"]
-}
-
 # demo.touchpoints.digital.gov TXT / ACME Challenge
 resource "aws_route53_record" "demo_touchpoints_digital_gov__acme-challenge_txt" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -551,19 +551,6 @@ resource "aws_route53_record" "demo_pra_digital_gov__acme-challenge_txt" {
   records = ["qzIXA_qU7a3io8b_FRxFVbPBUKZ83XtglufzS7qKnlg"]
 }
 
-# PRA Demo Redirect
-# redirect demo.pra.digital.gov to pra.digital.gov/
-module "demo_pra_digital_redirect_to_pra_digital" {
-  source  = "mediapop/redirect/aws"
-  version = "1.2.1"
-
-  domains = {
-    "demo.pra.digital.gov." = ["demo.pra.digital.gov"]
-  }
-
-  redirect_to = "https://pra.digital.gov/"
-}
-
 # demo.touchpoints.digital.gov TXT / ACME Challenge
 resource "aws_route53_record" "demo_touchpoints_digital_gov__acme-challenge_txt" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -521,6 +521,19 @@ resource "aws_route53_record" "demo_pra_digital_gov__acme-challenge_txt" {
   records = ["qzIXA_qU7a3io8b_FRxFVbPBUKZ83XtglufzS7qKnlg"]
 }
 
+# PRA Demo Redirect
+# redirect demo.pra.digital.gov to pra.digital.gov/
+module "demo_pra_digital_redirect_to_pra_digital" {
+  source  = "mediapop/redirect/aws"
+  version = "1.2.1"
+
+  domains = {
+    "demo.pra.digital.gov." = ["demo.pra.digital.gov"]
+  }
+
+  redirect_to = "https://pra.digital.gov/"
+}
+
 # demo.touchpoints.digital.gov TXT / ACME Challenge
 resource "aws_route53_record" "demo_touchpoints_digital_gov__acme-challenge_txt" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id


### PR DESCRIPTION
This pull request includes the required changes to the DNS records for pra.digital.gov to migrate the dns for the new cloud.gov service. in the `terraform/digital.gov.tf` file, primarily converting `A` and `AAAA` records to `CNAME` records and adding a new redirect module for the PRA demo site.

Changes to DNS records:

* Converted `A` and `AAAA` records to `CNAME` records for `pra.digital.gov` and `demo.pra.digital.gov`, including the corresponding `_acme-challenge` records. (`terraform/digital.gov.tf`)

New redirect module:

* Added a new redirect module to redirect `demo.pra.digital.gov` to `pra.digital.gov`. (`terraform/digital.gov.tf`)