### PR TITLE
Add new demo pra records

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -266,6 +266,24 @@ resource "aws_route53_record" "demo_pra_digital_gov_aaaa" {
   }
 }
 
+# demo.pra.digital.gov — CNAME -------------------------------
+resource "aws_route53_record" "demo_pra_digital_gov_cname" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "demo.pra.digital.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["demo.pra.digital.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "_acme-challenge_demo_pra_digital_gov_cname" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "_acme-challenge.demo.pra.digital.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["_acme-challenge.demo.pra.digital.gov.external-domains-production.cloud.gov."]
+}
+
+
 # Touchpoints ------------------------------------------------------------------
 # A simple, flexible, and convenient way to collect customer feedback.
 # Contact feedback-analytics@gsa.gov or digitalgov@gsa.gov

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -254,30 +254,30 @@ resource "aws_route53_record" "_acme-challenge_emerging_digital_gov_cname" {
 #}
 
 #resource "aws_route53_record" "_acme-challenge_pra_digital_gov_cname" {
-#  zone_id = aws_route53_zone.digital_toplevel.zone_id
-#  name    = "_acme-challenge.pra.digital.gov."
-#  type    = "CNAME"
-#  ttl     = 300
-#  records = ["_acme-challenge.pra.digital.gov.external-domains-production.cloud.gov."]
-#}
-
-
-
-# demo.pra.digital.gov — CNAME -------------------------------
-resource "aws_route53_record" "demo_pra_digital_gov_cname" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "demo.pra.digital.gov."
+  name    = "_acme-challenge.pra.digital.gov."
   type    = "CNAME"
   ttl     = 300
-  records = ["demo.pra.digital.gov.external-domains-production.cloud.gov."]
+  records = ["_acme-challenge.pra.digital.gov.external-domains-production.cloud.gov."]
+}
+
+
+
+# pra.digital.gov — CNAME -------------------------------
+resource "aws_route53_record" "demo_pra_digital_gov_cname" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "pra.digital.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["pra.digital.gov.external-domains-production.cloud.gov."]
 }
 
 #resource "aws_route53_record" "_acme-challenge_demo_pra_digital_gov_cname" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "_acme-challenge.demo.pra.digital.gov."
+  name    = "_acme-challenge.pra.digital.gov."
   type    = "CNAME"
   ttl     = 300
-  records = ["_acme-challenge.demo.pra.digital.gov.external-domains-production.cloud.gov."]
+  records = ["_acme-challenge.pra.digital.gov.external-domains-production.cloud.gov."]
 }
 
 # demo.pra.digital.gov — CNAME -------------------------------

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -264,21 +264,21 @@ resource "aws_route53_record" "_acme-challenge_emerging_digital_gov_cname" {
 
 
 # demo.pra.digital.gov — CNAME -------------------------------
-#resource "aws_route53_record" "demo_pra_digital_gov_cname" {
-#  zone_id = aws_route53_zone.digital_toplevel.zone_id
-#  name    = "demo.pra.digital.gov."
-#  type    = "CNAME"
-#  ttl     = 300
-#  records = ["demo.pra.digital.gov.external-domains-production.cloud.gov."]
-#}
+resource "aws_route53_record" "demo_pra_digital_gov_cname" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "demo.pra.digital.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["demo.pra.digital.gov.external-domains-production.cloud.gov."]
+}
 
 #resource "aws_route53_record" "_acme-challenge_demo_pra_digital_gov_cname" {
-#  zone_id = aws_route53_zone.digital_toplevel.zone_id
-#  name    = "_acme-challenge.demo.pra.digital.gov."
-#  type    = "CNAME"
-#  ttl     = 300
-#  records = ["_acme-challenge.demo.pra.digital.gov.external-domains-production.cloud.gov."]
-#}
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "_acme-challenge.demo.pra.digital.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["_acme-challenge.demo.pra.digital.gov.external-domains-production.cloud.gov."]
+}
 
 # demo.pra.digital.gov — CNAME -------------------------------
 resource "aws_route53_record" "demo_pra_digital_gov_cname" {

--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -245,26 +245,7 @@ resource "aws_route53_record" "_acme-challenge_emerging_digital_gov_cname" {
 
 
 # pra.digital.gov — CNAME -------------------------------
-#resource "aws_route53_record" "pra_digital_gov_cname" {
-#  zone_id = aws_route53_zone.digital_toplevel.zone_id
-#  name    = "pra.digital.gov."
-#  type    = "CNAME"
-#  ttl     = 300
-#  records = ["pra.digital.gov.external-domains-production.cloud.gov."]
-#}
-
-#resource "aws_route53_record" "_acme-challenge_pra_digital_gov_cname" {
-  zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "_acme-challenge.pra.digital.gov."
-  type    = "CNAME"
-  ttl     = 300
-  records = ["_acme-challenge.pra.digital.gov.external-domains-production.cloud.gov."]
-}
-
-
-
-# pra.digital.gov — CNAME -------------------------------
-resource "aws_route53_record" "demo_pra_digital_gov_cname" {
+resource "aws_route53_record" "pra_digital_gov_cname" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
   name    = "pra.digital.gov."
   type    = "CNAME"
@@ -272,7 +253,8 @@ resource "aws_route53_record" "demo_pra_digital_gov_cname" {
   records = ["pra.digital.gov.external-domains-production.cloud.gov."]
 }
 
-#resource "aws_route53_record" "_acme-challenge_demo_pra_digital_gov_cname" {
+# pra.digital.gov — CNAME ACME -------------------------------
+resource "aws_route53_record" "_acme-challenge_pra_digital_gov_cname" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
   name    = "_acme-challenge.pra.digital.gov."
   type    = "CNAME"
@@ -286,9 +268,10 @@ resource "aws_route53_record" "demo_pra_digital_gov_cname" {
   name    = "demo.pra.digital.gov."
   type    = "CNAME"
   ttl     = 300
-  records = ["demo.pra.digital.gov.external-domains-production.cloud.gov."]
+  records = ["pra.demo.digital.gov.external-domains-production.cloud.gov."]
 }
 
+# demo.pra.digital.gov — CNAME ACME  -------------------------------
 resource "aws_route53_record" "_acme-challenge_demo_pra_digital_gov_cname" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
   name    = "_acme-challenge.demo.pra.digital.gov."


### PR DESCRIPTION
Description:

- [ ] This is a new public-facing site
- [x] Provide context: Adding new demo.pra.digital.gov DNS records configured for cloud.gov external domain service. This is part 2 of 2 PRs to fix the DNS deployment issue.
- [ ] Assign to @18F/osc for review
- [ ] [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
- [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
Changes:

Added demo.pra.digital.gov CNAME record pointing to cloud.gov external domain service
Added _acme-challenge.demo.pra.digital.gov CNAME record for Let's Encrypt validation
This PR follows the cloud.gov external domain service requirements and should be merged after the first PR (remove-demo-pra-records) is merged and deployed.

The records are configured according to the cloud.gov external domain service documentation:

CNAME for demo.pra.digital.gov pointing to demo.pra.digital.gov.external-domains-production.cloud.gov
CNAME for _acme-challenge.demo.pra.digital.gov pointing to _acme-challenge.demo.pra.digital.gov.external-domains-production.cloud.gov