### PR TITLE
fix: Change typo in demo.pra.digital.gov CNAME value

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -268,7 +268,7 @@ resource "aws_route53_record" "demo_pra_digital_gov_cname" {
   name    = "demo.pra.digital.gov."
   type    = "CNAME"
   ttl     = 300
-  records = ["pra.demo.digital.gov.external-domains-production.cloud.gov."]
+  records = ["demo.pra.digital.gov.external-domains-production.cloud.gov."]
 }
 
 # demo.pra.digital.gov — CNAME ACME  -------------------------------


### PR DESCRIPTION
- [X] This is an update to an existing domain
   - [X] Fixes a typo in the CNAME value for `demo.pra.digital.gov`
