### PR TITLE
chore: Temp remove DNS records to later launch redirect dns

### DIFF
--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -6,85 +6,88 @@ resource "aws_route53_zone" "code_toplevel" {
   }
 }
 
-resource "aws_route53_record" "code_gov_apex" {
-  zone_id = aws_route53_zone.code_toplevel.zone_id
-  name    = "code.gov."
-  type    = "A"
 
-  alias {
-    name                   = "dqziuvpgrykcy.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
+// Remove code.gov records to allow for a redploy of the updated
+// record names.
+# resource "aws_route53_record" "code_gov_apex" {
+#   zone_id = aws_route53_zone.code_toplevel.zone_id
+#   name    = "code.gov."
+#   type    = "A"
 
-resource "aws_route53_record" "code_gov_apex_aaaa" {
-  zone_id = aws_route53_zone.code_toplevel.zone_id
-  name    = "code.gov."
-  type    = "AAAA"
+#   alias {
+#     name                   = "dqziuvpgrykcy.cloudfront.net."
+#     zone_id                = local.cloud_gov_cloudfront_zone_id
+#     evaluate_target_health = false
+#   }
+# }
 
-  alias {
-    name                   = "dqziuvpgrykcy.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
+# resource "aws_route53_record" "code_gov_apex_aaaa" {
+#   zone_id = aws_route53_zone.code_toplevel.zone_id
+#   name    = "code.gov."
+#   type    = "AAAA"
 
-resource "aws_route53_record" "code_gov_www" {
-  zone_id = aws_route53_zone.code_toplevel.zone_id
-  name    = "www.code.gov."
-  type    = "A"
+#   alias {
+#     name                   = "dqziuvpgrykcy.cloudfront.net."
+#     zone_id                = local.cloud_gov_cloudfront_zone_id
+#     evaluate_target_health = false
+#   }
+# }
 
-  alias {
-    name                   = "dqziuvpgrykcy.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
+# resource "aws_route53_record" "code_gov_www" {
+#   zone_id = aws_route53_zone.code_toplevel.zone_id
+#   name    = "www.code.gov."
+#   type    = "A"
 
-resource "aws_route53_record" "code_gov_www_aaaa" {
-  zone_id = aws_route53_zone.code_toplevel.zone_id
-  name    = "www.code.gov."
-  type    = "AAAA"
+#   alias {
+#     name                   = "dqziuvpgrykcy.cloudfront.net."
+#     zone_id                = local.cloud_gov_cloudfront_zone_id
+#     evaluate_target_health = false
+#   }
+# }
 
-  alias {
-    name                   = "dqziuvpgrykcy.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
+# resource "aws_route53_record" "code_gov_www_aaaa" {
+#   zone_id = aws_route53_zone.code_toplevel.zone_id
+#   name    = "www.code.gov."
+#   type    = "AAAA"
 
-resource "aws_route53_record" "staging_code_gov_a" {
-  zone_id = aws_route53_zone.code_toplevel.zone_id
-  name    = "staging.code.gov."
-  type    = "A"
+#   alias {
+#     name                   = "dqziuvpgrykcy.cloudfront.net."
+#     zone_id                = local.cloud_gov_cloudfront_zone_id
+#     evaluate_target_health = false
+#   }
+# }
 
-  alias {
-    name                   = "d3g0jy911fqt1l.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
+# resource "aws_route53_record" "staging_code_gov_a" {
+#   zone_id = aws_route53_zone.code_toplevel.zone_id
+#   name    = "staging.code.gov."
+#   type    = "A"
 
-resource "aws_route53_record" "staging_code_gov_aaaa" {
-  zone_id = aws_route53_zone.code_toplevel.zone_id
-  name    = "staging.code.gov."
-  type    = "AAAA"
+#   alias {
+#     name                   = "d3g0jy911fqt1l.cloudfront.net."
+#     zone_id                = local.cloud_gov_cloudfront_zone_id
+#     evaluate_target_health = false
+#   }
+# }
 
-  alias {
-    name                   = "d3g0jy911fqt1l.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
+# resource "aws_route53_record" "staging_code_gov_aaaa" {
+#   zone_id = aws_route53_zone.code_toplevel.zone_id
+#   name    = "staging.code.gov."
+#   type    = "AAAA"
 
-resource "aws_route53_record" "code_gov_api_cname" {
-  zone_id = aws_route53_zone.code_toplevel.zone_id
-  name    = "api.code.gov."
-  type    = "CNAME"
-  ttl     = 300
-  records = ["api-code-gov.domains.api.data.gov"]
-}
+#   alias {
+#     name                   = "d3g0jy911fqt1l.cloudfront.net."
+#     zone_id                = local.cloud_gov_cloudfront_zone_id
+#     evaluate_target_health = false
+#   }
+# }
+
+# resource "aws_route53_record" "code_gov_api_cname" {
+#   zone_id = aws_route53_zone.code_toplevel.zone_id
+#   name    = "api.code.gov."
+#   type    = "CNAME"
+#   ttl     = 300
+#   records = ["api-code-gov.domains.api.data.gov"]
+# }
 
 module "code_gov__email_security" {
   source  = "./email_security"


### PR DESCRIPTION
- Temporarily removes DNS records so they can be removed from route 53 and redeployed with the new [cloud.gov dns configurations](https://cloud.gov/docs/services/external-domain-service/).
