### PR TITLE
chore: Update CNAMES to relaunch code.gov

### DIFF
--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -65,6 +65,52 @@ resource "aws_route53_record" "code_gov__acme-challenge_www_code_gov_cname" {
 
 }
 
+## CNAME for staging.code.gov
+resource "aws_route53_record" "code_gov_staging_code_gov_cname" {
+  zone_id = aws_route53_zone.code_toplevel.zone_id
+  name    = "staging"
+  type    = "CNAME"
+
+  ttl     = 300
+  records = ["staging.code.gov.external-domains-production.cloud.gov."]
+
+}
+
+## CNAME Acme Challenge Record for staging.code.gov
+resource "aws_route53_record" "code_gov__acme-challenge_staging_code_gov_cname" {
+  zone_id = aws_route53_zone.code_toplevel.zone_id
+  name    = "_acme-challenge.staging"
+  type    = "CNAME"
+
+  ttl     = 300
+  records = ["_acme-challenge.staging.code.gov.external-domains-production.cloud.gov."]
+
+}
+
+## CNAME for api.code.gov
+resource "aws_route53_record" "code_gov_api_code_gov_cname" {
+  zone_id = aws_route53_zone.code_toplevel.zone_id
+  name    = "api"
+  type    = "CNAME"
+
+  ttl     = 300
+  records = ["api.code.gov.external-domains-production.cloud.gov."]
+
+}
+
+## CNAME Acme Challenge Record for api.code.gov
+resource "aws_route53_record" "code_gov__acme-challenge_api_code_gov_cname" {
+  zone_id = aws_route53_zone.code_toplevel.zone_id
+  name    = "_acme-challenge.api"
+  type    = "CNAME"
+
+  ttl     = 300
+  records = ["_acme-challenge.api.code.gov.external-domains-production.cloud.gov."]
+
+}
+
+
+
 # resource "aws_route53_record" "code_gov_api_cname" {
 #   zone_id = aws_route53_zone.code_toplevel.zone_id
 #   name    = "api.code.gov."

--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -7,8 +7,7 @@ resource "aws_route53_zone" "code_toplevel" {
 }
 
 
-// Remove code.gov records to allow for a redploy of the updated
-// record names.
+// Wait to deploy cloud.gov external domain service to set apex cloudfront name
 # resource "aws_route53_record" "code_gov_apex" {
 #   zone_id = aws_route53_zone.code_toplevel.zone_id
 #   name    = "code.gov."
@@ -33,53 +32,38 @@ resource "aws_route53_zone" "code_toplevel" {
 #   }
 # }
 
-# resource "aws_route53_record" "code_gov_www" {
-#   zone_id = aws_route53_zone.code_toplevel.zone_id
-#   name    = "www.code.gov."
-#   type    = "A"
+## CNAME Acme Challenge Record for code.gov
+resource "aws_route53_record" "code_gov__acme-challenge_code_gov_cname" {
+  zone_id = aws_route53_zone.code_toplevel.zone_id
+  name    = "_acme-challenge"
+  type    = "CNAME"
 
-#   alias {
-#     name                   = "dqziuvpgrykcy.cloudfront.net."
-#     zone_id                = local.cloud_gov_cloudfront_zone_id
-#     evaluate_target_health = false
-#   }
-# }
+  ttl     = 300
+  records = ["_acme-challenge.code.gov.external-domains-production.cloud.gov."]
 
-# resource "aws_route53_record" "code_gov_www_aaaa" {
-#   zone_id = aws_route53_zone.code_toplevel.zone_id
-#   name    = "www.code.gov."
-#   type    = "AAAA"
+}
 
-#   alias {
-#     name                   = "dqziuvpgrykcy.cloudfront.net."
-#     zone_id                = local.cloud_gov_cloudfront_zone_id
-#     evaluate_target_health = false
-#   }
-# }
+## CNAME for www.code.gov
+resource "aws_route53_record" "code_gov_www_code_gov_cname" {
+  zone_id = aws_route53_zone.code_toplevel.zone_id
+  name    = "www"
+  type    = "CNAME"
 
-# resource "aws_route53_record" "staging_code_gov_a" {
-#   zone_id = aws_route53_zone.code_toplevel.zone_id
-#   name    = "staging.code.gov."
-#   type    = "A"
+  ttl     = 300
+  records = ["www.code.gov.external-domains-production.cloud.gov."]
 
-#   alias {
-#     name                   = "d3g0jy911fqt1l.cloudfront.net."
-#     zone_id                = local.cloud_gov_cloudfront_zone_id
-#     evaluate_target_health = false
-#   }
-# }
+}
 
-# resource "aws_route53_record" "staging_code_gov_aaaa" {
-#   zone_id = aws_route53_zone.code_toplevel.zone_id
-#   name    = "staging.code.gov."
-#   type    = "AAAA"
+## CNAME Acme Challenge Record for www.code.gov
+resource "aws_route53_record" "code_gov__acme-challenge_www_code_gov_cname" {
+  zone_id = aws_route53_zone.code_toplevel.zone_id
+  name    = "_acme-challenge.www"
+  type    = "CNAME"
 
-#   alias {
-#     name                   = "d3g0jy911fqt1l.cloudfront.net."
-#     zone_id                = local.cloud_gov_cloudfront_zone_id
-#     evaluate_target_health = false
-#   }
-# }
+  ttl     = 300
+  records = ["_acme-challenge.www.code.gov.external-domains-production.cloud.gov."]
+
+}
 
 # resource "aws_route53_record" "code_gov_api_cname" {
 #   zone_id = aws_route53_zone.code_toplevel.zone_id


### PR DESCRIPTION
- Re-adds CNAMES to launch code.gov, www.code.gov,  api.code.gov, and staging.code.gov with cloud.gov's external domain configuration
- We need to wait to launch cloud.gov CDN service before we can update the A and AAAA records for the code.gov apex domain
- Will be used to redirect them to digital.gov