### PR TITLE
chore: Add code.gov A and AAAA records with CDN endpoint

### DIFF
--- a/terraform/code.gov.tf
+++ b/terraform/code.gov.tf
@@ -6,31 +6,29 @@ resource "aws_route53_zone" "code_toplevel" {
   }
 }
 
+resource "aws_route53_record" "code_gov_apex" {
+  zone_id = aws_route53_zone.code_toplevel.zone_id
+  name    = "code.gov."
+  type    = "A"
 
-// Wait to deploy cloud.gov external domain service to set apex cloudfront name
-# resource "aws_route53_record" "code_gov_apex" {
-#   zone_id = aws_route53_zone.code_toplevel.zone_id
-#   name    = "code.gov."
-#   type    = "A"
+  alias {
+    name                   = "d28gtishnkqf7k.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
 
-#   alias {
-#     name                   = "dqziuvpgrykcy.cloudfront.net."
-#     zone_id                = local.cloud_gov_cloudfront_zone_id
-#     evaluate_target_health = false
-#   }
-# }
+resource "aws_route53_record" "code_gov_apex_aaaa" {
+  zone_id = aws_route53_zone.code_toplevel.zone_id
+  name    = "code.gov."
+  type    = "AAAA"
 
-# resource "aws_route53_record" "code_gov_apex_aaaa" {
-#   zone_id = aws_route53_zone.code_toplevel.zone_id
-#   name    = "code.gov."
-#   type    = "AAAA"
-
-#   alias {
-#     name                   = "dqziuvpgrykcy.cloudfront.net."
-#     zone_id                = local.cloud_gov_cloudfront_zone_id
-#     evaluate_target_health = false
-#   }
-# }
+  alias {
+    name                   = "d28gtishnkqf7k.cloudfront.net."
+    zone_id                = local.cloud_gov_cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
 
 ## CNAME Acme Challenge Record for code.gov
 resource "aws_route53_record" "code_gov__acme-challenge_code_gov_cname" {


### PR DESCRIPTION
- Re adds the code.gov apex A and AAAA records with the redirect CDN endpoint
