### PR TITLE
fix: Hold on changing designsystem hostnames until CDN migration

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -394,13 +394,14 @@ resource "aws_route53_record" "designsystem_digital_gov_aaaa" {
 
 # designsystem.digital.gov — CNAME -------------------------------
 # (Setup for migrating to the new cloud.gov CDN service)
-resource "aws_route53_record" "designsystem_digital_gov_cname" {
-  zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "designsystem.digital.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["designsystem.digital.gov.external-domains-production.cloud.gov."]
-}
+# TODO: Uncomment this once we've migrated to the new cloud.gov CDN service
+# resource "aws_route53_record" "designsystem_digital_gov_cname" {
+#   zone_id = aws_route53_zone.digital_toplevel.zone_id
+#   name    = "designsystem.digital.gov."
+#   type    = "CNAME"
+#   ttl     = 120
+#   records = ["designsystem.digital.gov.external-domains-production.cloud.gov."]
+# }
 
 # designsystem.digital.gov acme challenge — CNAME -------------------------------
 resource "aws_route53_record" "acme_challenge_designsystem_digital_gov_cname" {
@@ -455,13 +456,14 @@ resource "aws_route53_record" "v1_designsystem_digital_gov_aaaa" {
   }
 }
 
-resource "aws_route53_record" "v1_designsystem_digital_gov_cname" {
-  zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "v1.designsystem.digital.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["v1.designsystem.digital.gov.external-domains-production.cloud.gov."]
-}
+# TODO: Uncomment this once we've migrated to the new cloud.gov CDN service
+# resource "aws_route53_record" "v1_designsystem_digital_gov_cname" {
+#   zone_id = aws_route53_zone.digital_toplevel.zone_id
+#   name    = "v1.designsystem.digital.gov."
+#   type    = "CNAME"
+#   ttl     = 120
+#   records = ["v1.designsystem.digital.gov.external-domains-production.cloud.gov."]
+# }
 
 resource "aws_route53_record" "acme_challenge_v1_designsystem_digital_gov_cname" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id


### PR DESCRIPTION
- Holds off changing the hostnames to use the new CNAME convention for designsystem.digital.gov and v1.designsystem.digital.gov until the acme challenge records deploy
- Fixes the TF apply so the `_acme-challenge...` CNAME records can deploy.
