### PR TITLE
change cname to A/AAAA records

### DIFF
--- a/terraform/innovation.gov.tf
+++ b/terraform/innovation.gov.tf
@@ -91,4 +91,3 @@ module "innovation_gov__email_security" {
 output "innovation_ns" {
   value = aws_route53_zone.innovation_toplevel.name_servers
 }
-}


### PR DESCRIPTION
- Proper CloudFront Distribution : Now using an actual CloudFront distribution URL (d2ntl68ywjm643.cloudfront.net) for apex and www records
- Consistent Configuration : Both apex and www point to the same CloudFront distribution
- Proper CNAME Records : The subdomain records for permitting and ce.permitting correctly use CNAME records pointing to cloud.gov


