### PR TITLE
update CNAME DNS record for tock.18f.gov

### DIFF
--- a/terraform/tock.18f.gov.tf
+++ b/terraform/tock.18f.gov.tf
@@ -12,7 +12,7 @@ resource "aws_route53_record" "d_18f_gov_tock_18f_gov_cname" {
   name    = "tock.18f.gov."
   type    = "CNAME"
   ttl     = 300
-  records = ["production-domains-1-884689640.us-gov-west-1.elb.amazonaws.com."]
+  records = ["tock.18f.gov.external-domains-production.cloud.gov."]
 }
 
 // Commented out to maintain compatibility with commented out 18f.gov.tf zone definition


### PR DESCRIPTION
Update CNAME record for tock.18f.gov to match expectations for external domain service: https://docs.cloud.gov/platform/services/external-domain-service/#how-to-create-an-instance-of-this-service

I have confirmed already that `tock.18f.gov.external-domains-production.cloud.gov` resolves and is working


- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@GSA-TTS/tts-tech-operations` for review
   - [ ] Review [GSA Pages Requirements](https://handbook.tts.gsa.gov/gsa-pages)
   - [ ] Review [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
