### PR TITLE
temporarily remove _acme-challenge records for touchpoints domains

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -509,14 +509,6 @@ resource "aws_route53_record" "demo_touchpoints_digital_gov_aaaa" {
   }
 }
 
-resource "aws_route53_record" "_acme-challenge_demo_touchpoints_digital_gov_cname" {
-  zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "_acme-challenge.demo.touchpoints.digital.gov."
-  type    = "CNAME"
-  ttl     = 300
-  records = ["_acme-challenge.demo.touchpoints.digital.gov.external-domains-production.cloud.gov."]
-}
-
 # DEMO Touchpoints APP / Amazon SES Verification TXT Record
 # demo.touchpoints.digital.gov
 resource "aws_route53_record" "demo_touchpoints_digital_gov_verification_txt" {
@@ -608,14 +600,6 @@ resource "aws_route53_record" "touchpoints_digital_gov_aaaa" {
     zone_id                = local.cloudfront_zone_id
     evaluate_target_health = false
   }
-}
-
-resource "aws_route53_record" "_acme-challenge_touchpoints_digital_gov_cname" {
-  zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "_acme-challenge.touchpoints.digital.gov."
-  type    = "CNAME"
-  ttl     = 300
-  records = ["_acme-challenge.touchpoints.digital.gov.external-domains-production.cloud.gov."]
 }
 
 # Touchpoints APP / Amazon SES Verification TXT Record
@@ -900,24 +884,6 @@ module "digital_gov__email_security" {
     "google-site-verification=Mi2rwVMxdp3eSbZughKvN0M_dwi6WLxMrRSsnLOWyVI",
     local.spf_hubspot
   ]
-}
-
-# demo.touchpoints.digital.gov TXT / ACME Challenge
-resource "aws_route53_record" "demo_touchpoints_digital_gov__acme-challenge_txt" {
-  zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "_acme-challenge.demo.touchpoints.digital.gov."
-  type    = "TXT"
-  ttl     = 120
-  records = ["n77f2RwJfGyS0NuSm-qIaf0FZEEURhqEACLML32hV0Y"]
-}
-
-# touchpoints.digital.gov TXT / ACME Challenge
-resource "aws_route53_record" "touchpoints_digital_gov__acme-challenge_txt" {
-  zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "_acme-challenge.touchpoints.digital.gov."
-  type    = "TXT"
-  ttl     = 120
-  records = ["Ho5lFIaJK7J44nLyBWGpfMBRNc96eL7-QnMuBII-4Uc"]
 }
 
 # standards.digital.gov — CNAME -------------------------------


### PR DESCRIPTION
- Removing changes from #804 since it failed to apply. Will restore the _acme-challenge CNAME records in a follow-up PR
- Removing _acme-challenge TXT records for demo.touchpoints.digital.gov and touchpoints.digital.gov since they conflict with [expectations of external domain service](https://docs.cloud.gov/news/2021/08/16/external-domain-migration-announcement/#what-you-need-to-do)

- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@GSA-TTS/tts-tech-operations` for review
   - [ ] Review [GSA Pages Requirements](https://handbook.tts.gsa.gov/gsa-pages)
   - [ ] Review [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
