### PR TITLE
add add CNAME _acme-challenge records for touchpoints

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -509,6 +509,14 @@ resource "aws_route53_record" "demo_touchpoints_digital_gov_aaaa" {
   }
 }
 
+resource "aws_route53_record" "_acme-challenge_demo_touchpoints_digital_gov_cname" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "_acme-challenge.demo.touchpoints.digital.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["_acme-challenge.demo.touchpoints.digital.gov.external-domains-production.cloud.gov."]
+}
+
 # DEMO Touchpoints APP / Amazon SES Verification TXT Record
 # demo.touchpoints.digital.gov
 resource "aws_route53_record" "demo_touchpoints_digital_gov_verification_txt" {
@@ -600,6 +608,14 @@ resource "aws_route53_record" "touchpoints_digital_gov_aaaa" {
     zone_id                = local.cloudfront_zone_id
     evaluate_target_health = false
   }
+}
+
+resource "aws_route53_record" "_acme-challenge_touchpoints_digital_gov_cname" {
+  zone_id = aws_route53_zone.digital_toplevel.zone_id
+  name    = "_acme-challenge.touchpoints.digital.gov."
+  type    = "CNAME"
+  ttl     = 300
+  records = ["_acme-challenge.touchpoints.digital.gov.external-domains-production.cloud.gov."]
 }
 
 # Touchpoints APP / Amazon SES Verification TXT Record


### PR DESCRIPTION
Adding _acme-challenge TXT records for demo.touchpoints.digital.gov and touchpoints.digital.gov to match [expectations of external domain service](https://docs.cloud.gov/news/2021/08/16/external-domain-migration-announcement/#what-you-need-to-do)

- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@GSA-TTS/tts-tech-operations` for review
   - [ ] Review [GSA Pages Requirements](https://handbook.tts.gsa.gov/gsa-pages)
   - [ ] Review [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
