### PR TITLE
Remove deprecated domains

### DIFF
--- a/terraform/consumeraction.gov.tf
+++ b/terraform/consumeraction.gov.tf
@@ -1,2 +1,0 @@
-# managed by Corporate IT - request changes through
-# https://gsa.servicenowservices.com/sp/?id=kb_article&sys_id=075cd185db26578058c2fd721f96193b

--- a/terraform/info.gov.tf
+++ b/terraform/info.gov.tf
@@ -1,2 +1,0 @@
-# managed by Corporate IT - request changes through
-# https://gsa.servicenowservices.com/sp/?id=kb_article&sys_id=075cd185db26578058c2fd721f96193b

--- a/terraform/kids.gov.tf
+++ b/terraform/kids.gov.tf
@@ -1,2 +1,0 @@
-# managed by Corporate IT - request changes through
-# https://gsa.servicenowservices.com/sp/?id=kb_article&sys_id=075cd185db26578058c2fd721f96193b

--- a/terraform/search.gov.tf
+++ b/terraform/search.gov.tf
@@ -54,25 +54,6 @@ resource "aws_route53_record" "www_search_gov_acme_challenge" {
   records = ["_acme-challenge.www.search.gov.external-domains-production.cloud.gov."]
 }
 
-
-## TEMPORARY for validation of planned hosting setup 2025-08-08
-resource "aws_route53_record" "whtnfrvemzeq_search_gov_acme_challenge" {
-  zone_id = aws_route53_zone.search_toplevel.zone_id
-  name    = "_acme-challenge.whtnfrvemzeq.search.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["_acme-challenge.whtnfrvemzeq.search.gov.external-domains-production.cloud.gov."]
-}
-
-## TEMPORARY for validation of planned hosting setup 2025-08-08
-resource "aws_route53_record" "search_gov_whtnfrvemzeq" {
-  zone_id = aws_route53_zone.search_toplevel.zone_id
-  name    = "whtnfrvemzeq.search.gov."
-  type    = "CNAME"
-  ttl     = 120
-  records = ["whtnfrvemzeq.search.gov.external-domains-production.cloud.gov."]
-}
-
 # find.search.gov
 resource "aws_route53_record" "search_gov_find" {
   zone_id = aws_route53_zone.search_toplevel.zone_id

--- a/terraform/us.gov.tf
+++ b/terraform/us.gov.tf
@@ -1,2 +1,0 @@
-# managed by Corporate IT - request changes through
-# https://gsa.servicenowservices.com/sp/?id=kb_article&sys_id=075cd185db26578058c2fd721f96193b

--- a/terraform/usagov.gov.tf
+++ b/terraform/usagov.gov.tf
@@ -1,2 +1,0 @@
-# managed by Corporate IT - request changes through
-# https://gsa.servicenowservices.com/sp/?id=kb_article&sys_id=075cd185db26578058c2fd721f96193b


### PR DESCRIPTION
Removes tf for these domains, which have already had their name service discontinued: 
 - consumeraction.gov
 - info.gov
 - kids.gov
 - us.gov
 - usagov.gov

Also removes a subdomain of search.gov that was used to test some things and is no longer needed. 

- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@GSA-TTS/tts-tech-operations` for review
   - [ ] Review [GSA Pages Requirements](https://handbook.tts.gsa.gov/gsa-pages)
   - [ ] Review [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
