### PR TITLE
change harvest.data.gov to use SSB cloudfront

### DIFF
--- a/terraform/data.gov.tf
+++ b/terraform/data.gov.tf
@@ -375,7 +375,7 @@ resource "aws_route53_record" "datagov_harvestdatagovexternaldomainsproductioncl
   type    = "CNAME"
 
   ttl     = 300
-  records = ["harvest.data.gov.external-domains-production.cloud.gov."]
+  records = ["d3g5uufc50sfwz.cloudfront.net"]
 
 }
 


### PR DESCRIPTION
Point harvest.data.gov use SSB cloudfront. 

cloud.gov’s `domain-with-cdn-dedicated-waf` CloudFront offering is currently not flexible enough to support Harvest’s requirements. We plan to use SSB-managed CloudFront to customize caching behavior, origin settings, and WAF rules. Once those configurations are validated, we can transition back to cloud.gov’s CloudFront with the finalized custom rules in place.